### PR TITLE
 Changed sppedd for ground laser as Vese engine does not like when

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -1209,7 +1209,7 @@
 		<thingClass>Projectile_Explosive</thingClass>
 		<projectile>
 			<damageDef>ShipLaserSmall</damageDef>
-			<speed>800</speed>
+			<speed>60</speed>
 			<explosionRadius>0</explosionRadius>
 			<flyOverhead>true</flyOverhead>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>


### PR DESCRIPTION
 weapon has notabble more than 60 (1 tile/tick) speed and not has huge
 explosion radius to hide hit inaccuracy in that case.