### PR TITLE
Fix: outer airlocks don't flick on landed ships, as they are not doors

### DIFF
--- a/Source/1.5/Building/Building_ShipAirlock.cs
+++ b/Source/1.5/Building/Building_ShipAirlock.cs
@@ -193,7 +193,7 @@ namespace SaveOurShip2
 				}
 			}
 			//Glow when opened
-			if (OpenPct > 0 && ticks % 16 == 0 && Outerdoor())
+			if (this.Map.IsSpace() && OpenPct > 0 && ticks % 16 == 0 && Outerdoor())
 				Map.flecks.CreateFleck(FleckMaker.GetDataStatic(DrawPos, Map, FleckDefOf.LightningGlow, 3));
 		}
 		public override IEnumerable<Gizmo> GetGizmos()


### PR DESCRIPTION
between vacuum and airtight rooms in this case.