### PR TITLE
Folow-up fix on ship weapons change preventing shuttle lasers on the

### DIFF
--- a/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.5/Projectile/Projectile_ExplosiveShip.cs
@@ -67,6 +67,16 @@ namespace SaveOurShip2
 				{
 					break;
 				}
+				if (!newTile.InBounds(base.Map, 0))
+				{
+					break;
+				}
+				// Do not advance past destination cell
+				if (currentPosition.ToIntVec3() == DestinationCell)
+				{
+					break;
+				}
+
 				List<Thing> thingList = newTile.GetThingList(base.Map);
 				bool hitBuildingOrVehicle = false;
 				foreach (Thing t in thingList)


### PR DESCRIPTION
ground from exploding their projectile after target. Map bounds check added.