### PR TITLE
Vehicle fixes:

### DIFF
--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4757,6 +4757,7 @@ namespace SaveOurShip2
 
 		public static bool Prefix(VehiclePawn __instance)
         {
+			Log.Warning("+ NEW Comp list");
 			CompsToAdd = new List<ThingComp>();
 			return true;
 		}
@@ -4765,24 +4766,16 @@ namespace SaveOurShip2
         {
 			foreach (ThingComp comp in CompsToAdd)
 			{
-				__instance.comps.Add(comp);
-				PostSpawnNewComponents.CompsToSpawn.Add(comp);
+				__instance.AddComp(comp);
 			}
-			__instance.RecacheComponents();
 		}
 	}
 
 	[HarmonyPatch(typeof(VehiclePawn), "SpawnSetup")]
 	public static class PostSpawnNewComponents
 	{
-		public static List<ThingComp> CompsToSpawn=new List<ThingComp>();
-		public static float ShieldGenHealth = 0;
-		public static float StoredHeat = 0;
-
 		public static bool Prefix(VehiclePawn __instance, bool respawningAfterLoad)
 		{
-			if(respawningAfterLoad)
-				CompsToSpawn = new List<ThingComp>();
 			return true;
 		}
 
@@ -4795,17 +4788,29 @@ namespace SaveOurShip2
 					net2.RebuildHeatNet();
 				return;
 			}
-			foreach (ThingComp comp in CompsToSpawn)
-				comp.PostSpawnSetup(true);
 			CompVehicleHeatNet net = __instance.GetComp<CompVehicleHeatNet>();
 			if (net != null)
 			{
+				if (__instance.Spawned)
+				{
+					net.PostSpawnSetup(true);
+				}
 				net.RebuildHeatNet();
-				net.myNet.AddHeat(StoredHeat);
 			}
 			VehicleComponent shieldGen = __instance.statHandler.components.FirstOrDefault(comp => comp.props.key == "shieldGenerator");
-			if (shieldGen != null && ShieldGenHealth != 1)
-				shieldGen.health = ShieldGenHealth;
+			if (shieldGen != null)
+			{
+				CompShipHeatShield compShield = __instance.TryGetComp<CompShipHeatShield>();
+				ShipMapComp mapComp = __instance.Map.GetComponent<ShipMapComp>();
+				if (mapComp != null && compShield != null)
+				{
+					if (__instance.Spawned)
+					{
+						compShield.PostSpawnSetup(true);
+					}
+					mapComp.Shields.Add(compShield);
+				}
+			}
 		}
 	}
 

--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -3233,10 +3233,11 @@ namespace SaveOurShip2
 				if (Rand.RangeInclusive(chance, 10) > 5) //shields
 				{
 					shields = true;
-					if (size > 2 || (size > 1 && Rand.Bool))
+					// TODO: Temporary disable spawning enemy shields
+					/*if (size > 2 || (size > 1 && Rand.Bool))
 						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("ShieldsHeavy"));
 					else
-						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("ShieldsBasic"));
+						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("ShieldsBasic"));*/
 				}
 				if (Rand.RangeInclusive(chance, 10) > 6) //armor
 				{
@@ -3259,10 +3260,12 @@ namespace SaveOurShip2
 				}
 				if (Rand.RangeInclusive(chance, 10) > 7) //util
 				{
-					if (size > 1 && Rand.Bool)
+					// TODO: Temporary disable spawning cloak and heatsink too
+
+					/*if (size > 1 && Rand.Bool)
 						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("CargoCloaking"));
 					else if (shields)
-						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("CargoHeatsink"));
+						vehicle.CompUpgradeTree.FinishUnlock(vehicle.CompUpgradeTree.Props.def.GetNode("CargoHeatsink"));*/
 				}
 			}
 		}

--- a/Source/1.5/Vehicles/CompShuttleLauncher.cs
+++ b/Source/1.5/Vehicles/CompShuttleLauncher.cs
@@ -186,11 +186,6 @@ namespace SaveOurShip2.Vehicles
             Scribe_Values.Look<float>(ref retreatAtHealth, "retreatAtHealth");
             Scribe_Values.Look<float>(ref serializedHeat, "heat");
             Scribe_Values.Look<float>(ref serializedShieldGenHealth, "shieldGenHealth");
-            if (Scribe.mode == LoadSaveMode.PostLoadInit)
-            {
-                PostSpawnNewComponents.ShieldGenHealth = serializedShieldGenHealth;
-                PostSpawnNewComponents.StoredHeat = serializedHeat;
-            }
         }
     }
 }

--- a/Source/1.5/Vehicles/ShuttleShieldUpgrade.cs
+++ b/Source/1.5/Vehicles/ShuttleShieldUpgrade.cs
@@ -44,10 +44,7 @@ namespace SaveOurShip2.Vehicles
             {
                 net = new CompVehicleHeatNet();
                 net.parent = vehicle;
-                if (!unlockingAfterLoad)
-                    vehicle.comps.Add(net);
-                else
-                    PostLoadNewComponents.CompsToAdd.Add(net);
+                vehicle.AddComp(net);
             }
             VehicleComponent shieldGenerator = vehicle.statHandler.componentsByKeys["shieldGenerator"];
             shieldGenerator.SetHealthModifier = 50;
@@ -55,10 +52,9 @@ namespace SaveOurShip2.Vehicles
             CompShipHeatShield myShield = new CompShipHeatShield();
             myShield.parent = vehicle;
             myShield.Initialize(shield);
+            vehicle.AddComp(myShield);
             if (!unlockingAfterLoad)
             {
-                vehicle.comps.Add(myShield);
-                vehicle.RecacheComponents();
                 if (vehicle.Spawned)
                 {
                     myShield.PostSpawnSetup(unlockingAfterLoad);
@@ -68,8 +64,6 @@ namespace SaveOurShip2.Vehicles
                         mapComp.Shields.Add(myShield);
                 }
             }
-            else
-                PostLoadNewComponents.CompsToAdd.Add(myShield);
         }
     }
 }

--- a/Source/1.5/Vehicles/SoS2TurretUpgrade.cs
+++ b/Source/1.5/Vehicles/SoS2TurretUpgrade.cs
@@ -26,12 +26,7 @@ namespace SaveOurShip2.Vehicles
             if(useShuttleFuel)
                 newTurret.shellCount = newTurret.turretDef.magazineCapacity;
 
-            newTurret.SetTarget(LocalTargetInfo.Invalid);
-            newTurret.ResetAngle();
-            newTurret.FillEvents_Def();
-            compTurrets.turrets.Add(newTurret);
-            compTurrets.RevalidateTurrets();
-            compTurrets.CheckDuplicateKeys();
+            vehicle.CompVehicleTurrets.AddTurret(newTurret, node.key);
         }
     }
 }


### PR DESCRIPTION
1. Fixed yellow error on loading turrets - they were added with null upgrade key
2. Fixed shield not appearing on player shulltle after save/load.
3. Heat net thing not fixed yet, but for now heatsink, cloaking device and shields temporary disabled for enemy shuttles - won't generate. No 3 results in can play a battle with Strike carrier, either retreating or accepting shutlles arrival in combat several times, without red log errors related to shuttlers. Which improves playablity a lot. Until heat net for shuttle fixed.