### PR TITLE
Set enemy shuttles faction to null on defeat, so that they don't prevent

### DIFF
--- a/Source/1.5/Comp/ShipMapComp.cs
+++ b/Source/1.5/Comp/ShipMapComp.cs
@@ -2561,6 +2561,20 @@ namespace SaveOurShip2
 				DeRegisterShuttleMission(mission);
 			}
 
+			if (loser != ShipInteriorMod2.FindPlayerShipMap())
+			{
+				// AI lost. Reset all their shuttles faction, so that thaey don't prevent buildings capture,
+				// becuse of being enemy pawns, which is totally not evident for the player.
+				foreach (VehiclePawn veh in loser.mapPawns.AllPawnsSpawned.Where(pawn => pawn is VehiclePawn veh))
+				{
+					if (veh.Faction.HostileTo(Faction.OfPlayer))
+					{
+						veh.DisembarkAll();
+						veh.SetFaction(null);
+						veh.ignition.Drafted = false;
+					}
+				}
+			}
 			//td temp
 			tgtMapComp.ShipCombatTargetMap = null;
 			tgtMapComp.originMapComp = null;


### PR DESCRIPTION
player from capturing buildings, while it is totally not evident for player thatthey are enemy pawns.