### PR TITLE
XML Fixes and adjustments:

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1922,8 +1922,8 @@
 		<fillPercent>0.40</fillPercent>
 		<tickerType>Normal</tickerType>
 		<statBases>
-			<MaxHitPoints>100</MaxHitPoints>
-			<WorkToBuild>800</WorkToBuild>
+			<MaxHitPoints>200</MaxHitPoints>
+			<WorkToBuild>4000</WorkToBuild>
 			<Mass>200</Mass>
 			<Flammability>0</Flammability>
 		</statBases>

--- a/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -36,6 +36,7 @@
 		<pathCost>50</pathCost>
 		<tickerType>Normal</tickerType>
 		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+		<holdsRoof>true</holdsRoof>
 		<designationCategory>Ship</designationCategory>
 		<statBases>
 			<MaxHitPoints>1000</MaxHitPoints>
@@ -291,6 +292,7 @@
 	<ThingDef ParentName="ShipHeatsinkBase">
 		<defName>ShipHeatsink</defName>
 		<label>heatsink</label>
+		<holdsRoof>true</holdsRoof>
 		<altitudeLayer>Gas</altitudeLayer>
 		<description>A heatsink that slowly removes heat from the heat network. Will take damage if coolant gets near maximum heat capacity and release all heat stored if destroyed. Will slowly replenish capacity from depletion when not in battle. Does not function if the ship is cloaked.\n\nHeat capacity: 200Hu\nHeat vented to space: 4Hu/s\nHeat loss: 1Hu/s</description>
 		<size>(2,2)</size>
@@ -340,6 +342,7 @@
 	<ThingDef ParentName="ShipHeatsinkBase">
 		<defName>ShipHeatsinkLarge</defName>
 		<label>large heatsink</label>
+		<holdsRoof>true</holdsRoof>
 		<altitudeLayer>Gas</altitudeLayer>
 		<description>A large heatsink that slowly removes heat from the heat network. Will take damage if coolant gets near maximum heat capacity and release all heat stored if destroyed. Will slowly replenish capacity from depletion when not in battle. Does not function if the ship is cloaked.\n\nHeat capacity: 1000Hu\nHeat vented to space: 16Hu/s\nHeat loss: 3Hu/s</description>
 		<size>(4,4)</size>

--- a/1.5/Defs/ThingDefs_Misc/Apparel_Space.xml
+++ b/1.5/Defs/ThingDefs_Misc/Apparel_Space.xml
@@ -168,7 +168,7 @@
 		<statBases>
 			<WorkToMake>16000</WorkToMake>
 			<MaxHitPoints>160</MaxHitPoints>
-			<Mass>2.7</Mass>
+			<Mass>1.5</Mass>
 			<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 			<ArmorRating_Heat>0.75</ArmorRating_Heat>
@@ -232,7 +232,7 @@
 		<statBases>
 			<WorkToMake>16000</WorkToMake>
 			<MaxHitPoints>160</MaxHitPoints>
-			<Mass>2.7</Mass>
+			<Mass>1</Mass>
 			<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.4</ArmorRating_Sharp>
 			<ArmorRating_Heat>0.75</ArmorRating_Heat>
@@ -394,7 +394,7 @@
 		<statBases>
 			<WorkToMake>21000</WorkToMake>
 			<MaxHitPoints>150</MaxHitPoints>
-			<Mass>1.5</Mass>
+			<Mass>2.7</Mass>
 			<Flammability>0.4</Flammability>
 			<ArmorRating_Sharp>1.06</ArmorRating_Sharp>
 			<ArmorRating_Blunt>0.45</ArmorRating_Blunt>


### PR DESCRIPTION
1. Helmets weights adjusted, now Heavy EVA Helmet > EVA Helmet > Kid Helmet
2. Ship Capacitor Array HP 100 => 200, still fragile but not the same as small ship capacitor. Build time increased to be times larger than for small one too.
3. Buldings visible over roof, ship weapons and heatsinks (except for anti-entropic) now support roof.