### PR TITLE
Fix MapHelper.TryLinkMapToWorldObject throwing empty sequence exceptions

### DIFF
--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -3321,7 +3321,7 @@ namespace SaveOurShip2
 		{
 			// For now, issue was found with Escape Ship map due to that map not being linked to world object
 			// So, fixing onlyy that case for now
-			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).Where(t => t is EscapeShip).First();
+			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).FirstOrDefault(t => t is EscapeShip);
 			if (worldObject != null && worldObject.Faction != Faction.OfPlayer)
 			{
 				// Link map to Escap ship object sho that it gets "Home" icon and when selected on world map, there is Abadon option 


### PR DESCRIPTION
It looks like it's supposed to do nothing when there isn't a worldObject that is an EscapeShip.

This makes it actually do nothing instead of throwing an exception when there is no worldObject on the tile that is an EscapeShip.

Found this when sending a shuttle to a Rimnauts asteroid map. Shuttle just went and poof'ed.