### PR TITLE
In player starting things, enable mechanoids to spawn on ship/station

### DIFF
--- a/Source/1.5/ScenPart/ScenPart_StartInSpace.cs
+++ b/Source/1.5/ScenPart/ScenPart_StartInSpace.cs
@@ -227,7 +227,7 @@ namespace SaveOurShip2
 			int num = 0;
 			foreach (Thing item in list3)
 			{
-				if (!(item is Pawn))
+				if (!(item is Pawn) || ((item is Pawn p) && (p.RaceProps?.IsMechanoid ?? false)))
 				{
 					if (item.def.CanHaveFaction)
 					{


### PR DESCRIPTION
start. Animals don't fit there, so won't spawn, that is unchanged.