### PR TITLE
Personal pods on shuttle bays

### DIFF
--- a/Source/1.5/Comp/CompShipBay.cs
+++ b/Source/1.5/Comp/CompShipBay.cs
@@ -183,7 +183,7 @@ namespace SaveOurShip2
 					ReCacheDockedShuttles();
 				foreach (CompFueledTravel comp in dockedShuttles)
 				{
-					if (compRefuelable.fuel > 0 && comp.FuelPercentOfTarget < 1 && !comp.Vehicle.ignition.Drafted)
+					if (compRefuelable.fuel > 0 && comp.FuelPercentOfTarget < 1 && !comp.Vehicle.ignition.Drafted && compRefuelable.Props.fuelFilter.Allows(comp.Props.fuelType))
 					{
 						comp.Refuel(1);
 						compRefuelable.ConsumeFuel(1);
@@ -211,8 +211,14 @@ namespace SaveOurShip2
 				if(shuttle!=null)
                 {
 					CompFueledTravel fueledTravel = shuttle.GetComp<CompFueledTravel>();
-					if (fueledTravel != null && fueledTravel.Props.fuelType == ResourceBank.ThingDefOf.ShuttleFuelPods)
+					if (fueledTravel == null)
+					{
+						return;
+					}
+					if (shuttle.def == ResourceBank.ThingDefOf.SoS2_Shuttle_Personal ||  fueledTravel.Props.fuelType == ResourceBank.ThingDefOf.ShuttleFuelPods)
+					{
 						dockedShuttles.Add(fueledTravel);
+					}
                 }
             }
         }


### PR DESCRIPTION
Moved over from other repo, primarily. This allows personal shuttles to dock on bays (and be repaired), and also checks fuel type on refilling (to avoid uranium filling pods, but also to allow a submod with chemfuel bays to refill pods) 