### PR TITLE
Fix for load ship scenario. When ideology system inactive option was …

### DIFF
--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -3764,7 +3764,7 @@ namespace SaveOurShip2
 
 		public static void Postfix(Page_ChooseIdeoPreset __instance)
 		{
-			if (ShipInteriorMod2.LoadShipFlag)
+			if (ShipInteriorMod2.LoadShipFlag && !ShipInteriorMod2.LoadShipClassicIdeoMode)
 			{
 				foreach (Faction allFaction in Find.FactionManager.AllFactions)
 				{

--- a/Source/1.5/ScenPart/ScenPart_LoadShip.cs
+++ b/Source/1.5/ScenPart/ScenPart_LoadShip.cs
@@ -174,6 +174,7 @@ namespace SaveOurShip2
 			Scribe_Values.Look(ref playerFactionName, "playerFactionName");
 			//typeof(GameDataSaveLoader).GetField("isSavingOrLoadingExternalIdeo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).SetValue(null, true);
 			Scribe_Deep.Look(ref playerFactionIdeo, "playerFactionIdeo");
+			Scribe_Values.Look(ref ShipInteriorMod2.LoadShipClassicIdeoMode, "classicMode", false);
 			Scribe_Collections.Look<Ideo>(ref ideosAboardShip, "ideos", LookMode.Deep);
 			//typeof(GameDataSaveLoader).GetField("isSavingOrLoadingExternalIdeo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).SetValue(null, false);
 			Scribe_Deep.Look<TickManager>(ref tickManager, false, "tickManager");

--- a/Source/1.5/ShipInteriorMod2.cs
+++ b/Source/1.5/ShipInteriorMod2.cs
@@ -151,6 +151,7 @@ namespace SaveOurShip2
 		public static Map shipOriginMap = null; //used to check for shipmove map size problem in placeworker, reset after move
 		public static bool SaveShipFlag; //used in patch to trigger ending scene
 		public static bool LoadShipFlag; //set to true in ScenPart_LoadShip.PostWorldGenerate and false in the patch to MapGenerator.GenerateMap
+		public static bool LoadShipClassicIdeoMode; // Has to be applied with a delay when loading ship
 		public static bool StartShipFlag; //as above but for ScenPart_StartInSpace
 		public static bool ArchoIdeoFlag;
 		public static bool MoveShipFlag //set on ship move/remove
@@ -2936,6 +2937,7 @@ namespace SaveOurShip2
 				Scribe_Values.Look(ref playerFactionName, "playerFactionName");
 				//typeof(GameDataSaveLoader).GetField("isSavingOrLoadingExternalIdeo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).SetValue(null, true);
 				Scribe_Deep.Look(ref playerFactionIdeo, "playerFactionIdeo");
+				Scribe_Values.Look(ref Find.IdeoManager.classicMode, "classicMode", forceSave:true);
 				//typeof(GameDataSaveLoader).GetField("isSavingOrLoadingExternalIdeo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static).SetValue(null, false);
 
 				Scribe_Deep.Look<TickManager>(ref Current.Game.tickManager, true, "tickManager");


### PR DESCRIPTION
…selected in

previous game, that flag will be carried to next game, allowing player to choose that option again at startup and player pawns will have hidded default ideo.