### PR TITLE
Adden null check in harmony patch, which can be the case in other mods

### DIFF
--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4735,7 +4735,11 @@ namespace SaveOurShip2
     {
 		public static void Postfix(CompUpgradeTree __instance, UpgradeNode node, ref bool __result)
         {
-			if(node.upgrades.Where(upgrade=>upgrade is SoS2TurretUpgrade sosUpgrade && sosUpgrade.turretSlot >= __instance.Vehicle.GetStatValue(ResourceBank.VehicleStatDefOf.Hardpoints)).Count()>0)
+			if (node.upgrades == null)
+			{
+				return;
+			}
+			if (node.upgrades.Where(upgrade=>upgrade is SoS2TurretUpgrade sosUpgrade && sosUpgrade.turretSlot >= __instance.Vehicle.GetStatValue(ResourceBank.VehicleStatDefOf.Hardpoints)).Count()>0)
             {
 				__result = true;
             }


### PR DESCRIPTION
and cause errors without check.