### PR TITLE
Shuttles get autofire ability for laser and plasma, in order to not get

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/UpgradeTree.xml
+++ b/1.5/Defs/ThingDefs_Buildings/UpgradeTree.xml
@@ -978,7 +978,7 @@
 								<turretDef>SoS2ShuttleLaser</turretDef>
 								
 								<gizmoLabel>Laser Turret A</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>laserTurretA</key>
 							</li>
@@ -1024,7 +1024,7 @@
 								<turretDef>SoS2ShuttlePlasma</turretDef>
 								
 								<gizmoLabel>Plasma Turret A</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>plasmaTurretA</key>
 							</li>
@@ -1114,7 +1114,7 @@
 								<turretDef>SoS2ShuttleLaser</turretDef>
 								
 								<gizmoLabel>Laser Turret B</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>laserTurretB</key>
 							</li>
@@ -1160,7 +1160,7 @@
 								<turretDef>SoS2ShuttlePlasma</turretDef>
 								
 								<gizmoLabel>Plasma Turret B</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>plasmaTurretB</key>
 							</li>
@@ -1250,7 +1250,7 @@
 								<turretDef>SoS2ShuttleLaser</turretDef>
 								
 								<gizmoLabel>Laser Turret C</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>laserTurretC</key>
 							</li>
@@ -1296,7 +1296,7 @@
 								<turretDef>SoS2ShuttlePlasma</turretDef>
 								
 								<gizmoLabel>Plasma Turret C</gizmoLabel>
-								<autoTargeting>false</autoTargeting>
+								<autoTargeting>true</autoTargeting>
 								
 								<key>plasmaTurretC</key>
 							</li>
@@ -1374,9 +1374,9 @@
 		<shotSound>ShipCombatLaser</shotSound>
 		
 		<reloadTimer>25.0</reloadTimer>
-		
+
 		<projectile>Shuttle_Laser</projectile>
-		<warmUpTimer>1.5</warmUpTimer>
+		<warmUpTimer>3.5</warmUpTimer>
 		
 		<magazineCapacity>6</magazineCapacity>
 		
@@ -1456,7 +1456,7 @@
 		<reloadTimer>25.0</reloadTimer>
 		
 		<projectile>Shuttle_Plasma</projectile>
-		<warmUpTimer>1.5</warmUpTimer>
+		<warmUpTimer>3.5</warmUpTimer>
 		
 		<autoSnapTargeting>false</autoSnapTargeting>
 		<rotationSpeed>2</rotationSpeed>

--- a/Source/1.5/HarmonyPatches.cs
+++ b/Source/1.5/HarmonyPatches.cs
@@ -4829,6 +4829,19 @@ namespace SaveOurShip2
         }
     }
 
+	[HarmonyPatch(typeof(Command_CooldownAction), "DrawBottomBar")]
+	public static class DontDrawExtraBarForVehicleTurrets
+	{
+		public static bool Prefix(Command_CooldownAction __instance)
+		{
+			if(__instance.turret.turretDef.defName == "SoS2ShuttlePlasma" || (__instance.turret.turretDef.defName == "SoS2ShuttleLaser"))
+			{
+				return false;
+			}
+			return true;
+		}
+	}
+
 	[HarmonyPatch(typeof(VehiclePawn), "ExposeData")]
 	public static class VehicleExposeData
 	{

--- a/Source/1.5/Vehicles/SoS2VehicleTurret.cs
+++ b/Source/1.5/Vehicles/SoS2VehicleTurret.cs
@@ -51,8 +51,17 @@ namespace SaveOurShip2.Vehicles
             get
             {
                 if (isTorpedo)
+                {
                     return base.SubGizmos;
-                return new List<SubGizmo>();
+                }
+                else if (autoTargeting)
+                {
+                    return new List<SubGizmo>() { SubGizmo_AutoTarget(this) };
+                }
+                else
+				{
+                    return new List<SubGizmo>();
+                }
             }
         }
 


### PR DESCRIPTION
way to OP, warmup is increased from 1.5 to 3.5. Cooldown/reload is disabled for those weapons, so can't be incresed for balancing.