### PR TITLE
Bring Spinal Plasma shield damage in line with "less range more DPS,

### DIFF
--- a/Source/1.5/Comp/CompShipHeatShield.cs
+++ b/Source/1.5/Comp/CompShipHeatShield.cs
@@ -97,7 +97,7 @@ namespace SaveOurShip2
 		}
 
 		public static Dictionary<ThingDef, float> ProjectileToMult = new Dictionary<ThingDef, float>() {
-			{ThingDef.Named("Proj_ShipSpinalBeamPlasma"), 1.5f},
+			{ThingDef.Named("Proj_ShipSpinalBeamPlasma"), 2.4f},
 			{ThingDef.Named("Bullet_Torpedo_HighExplosive"), 0.33f},
 			{ThingDef.Named("Bullet_Torpedo_EMP"), 10f},
 			{ThingDef.Named("Bullet_Torpedo_Antimatter"), 0.33f},


### PR DESCRIPTION
more range less DPS" rule. Perfiously, was wealer that longer-ranged railguns in that area.