### PR TITLE
Fixed spinal amplifier damage multiplier lost due to native damage multilier support removed in 1.6.

### DIFF
--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -2508,20 +2508,20 @@ namespace SaveOurShip2
 		}
 	}
 
-	/*[HarmonyPatch(typeof(Projectile), "Launch", new Type[] {
+	[HarmonyPatch(typeof(Projectile), "Launch", new Type[] {
 		typeof(Thing), typeof(Vector3), typeof(LocalTargetInfo), typeof(LocalTargetInfo),
 		typeof(ProjectileHitFlags), typeof(bool), typeof(Thing), typeof(ThingDef) })] //td? move this into ship turret/launch code
 	public static class TransferAmplifyBonus
 	{
-		public static void Postfix(Projectile __instance, Thing equipment, ref float ___weaponDamageMultiplier)
+		public static void Postfix(Projectile __instance, Thing equipment)
 		{
 			if (__instance is Projectile_ExplosiveShip && equipment is Building_ShipTurret turret &&
 				turret.AmplifierDamageBonus > 0)
 			{
-				___weaponDamageMultiplier = 1 + turret.AmplifierDamageBonus;
+				(__instance as Projectile_ExplosiveShip).weaponDamageMultiplier = 1 + turret.AmplifierDamageBonus;
 			}
 		}
-	}*/
+	}
 
 	//crypto
 	[HarmonyPatch(typeof(Building_CryptosleepCasket), "FindCryptosleepCasketFor")]

--- a/Source/1.6/Projectile/Projectile_ExplosiveShip.cs
+++ b/Source/1.6/Projectile/Projectile_ExplosiveShip.cs
@@ -26,6 +26,13 @@ namespace SaveOurShip2
 	public class Projectile_ExplosiveShip : Projectile_Explosive
 	{
 		public float weaponDamageMultiplier = 1f;
+		public override int DamageAmount
+		{
+			get
+			{
+				return (int)(weaponDamageMultiplier * base.DamageAmount);
+			}
+		}
 		protected override void Impact(Thing hitThing, bool blockedByShield = false)
 		{
 			// Projectile position can be inaccurate by several tiles if it travels several tiles per tick, Verse issue

--- a/Source/1.6/Vehicles/CompHoverMode.cs
+++ b/Source/1.6/Vehicles/CompHoverMode.cs
@@ -39,7 +39,6 @@ namespace SaveOurShip2.Vehicles
                         LandingTargeter.Instance.BeginTargeting(Vehicle, Vehicle.Map, delegate (LocalTargetInfo target, Rot4 rot)
                         {
                             // CHANGE 1.6 LaunchTargeter.FlightPath = new List<FlightNode> { new FlightNode(Vehicle.Map.Tile) };
-                            // CHANGE 1.6
                             TargetData<GlobalTargetInfo> targetData = new TargetData<GlobalTargetInfo>();
                             targetData.targets.Add(new GlobalTargetInfo(Vehicle.Map.Tile));
                             Vehicle.CompVehicleLauncher.Launch(targetData, new ArrivalAction_LandToCell(Vehicle, Vehicle.Map.Parent, target.Cell, rot));


### PR DESCRIPTION

Important: it can't use damage multiplier from weapon because by the time projectile hits, launching spinal may be destroyed or damaged.