### PR TITLE
fix: random null ref when scanner found navy

### DIFF
--- a/Source/1.6/Comp/CompShipScanner.cs
+++ b/Source/1.6/Comp/CompShipScanner.cs
@@ -181,7 +181,7 @@ namespace SaveOurShip2
 						ship.derelictShip = navy.spaceShipDefs.Where(def => def.spaceSite && !def.neverRandom && def.rarityLevel <= Rand.RangeInclusive(1, 2)).RandomElement();
 						ship.shipFaction = Find.FactionManager.AllFactions.Where(f => navy.factionDefs.Contains(f.def)).RandomElement();
 						ship.spaceNavyDef = navy;
-						if (ship.derelictShip.neverWreck)
+						if (ship.derelictShip?.neverWreck ?? false)
 							ship.wreckLevel = 0;
 						else
 							ship.wreckLevel = Rand.RangeInclusive(0, 3);


### PR DESCRIPTION
`ship.derelictShip` could be null and should be handled below instead of an exception.