### PR TITLE
fix: local flight target is tile rather than worldobject

### DIFF
--- a/Source/1.6/Vehicles/CompHoverMode.cs
+++ b/Source/1.6/Vehicles/CompHoverMode.cs
@@ -40,7 +40,7 @@ namespace SaveOurShip2.Vehicles
                         {
                             // CHANGE 1.6 LaunchTargeter.FlightPath = new List<FlightNode> { new FlightNode(Vehicle.Map.Tile) };
                             TargetData<GlobalTargetInfo> targetData = new TargetData<GlobalTargetInfo>();
-                            targetData.targets.Add(new GlobalTargetInfo(Vehicle.Map.Tile));
+                            targetData.targets.Add(Vehicle.Map.Parent != null ? new GlobalTargetInfo(Vehicle.Map.Parent) : new GlobalTargetInfo(Vehicle.Map.Tile));
                             Vehicle.CompVehicleLauncher.Launch(targetData, new ArrivalAction_LandToCell(Vehicle, Vehicle.Map.Parent, target.Cell, rot));
                         }, (LocalTargetInfo targetInfo) => !Ext_Vehicles.IsRoofRestricted(Vehicle.VehicleDef, targetInfo.Cell, Vehicle.Map), null, null, true);
                     },


### PR DESCRIPTION
https://github.com/SmashPhil/Vehicle-Framework/commit/3d3b63dbac53375f816769915e70094a1661b047

After the Vehicle Framework fixes the launching position, the shuttle now starts from the correct position, but the target of "Local flight" is still the map tile. This PR should fix the behavior after the Vehicle Framework update.

Notice: This PR should be released only after the Vehicle Framework releases its version, otherwise the "Local flight" will be broken because trying to fly from tile to worldobject.