### PR TITLE
Vehicle Frameowrk has target class for Harmony patch renamed, and it

### DIFF
--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -5023,7 +5023,7 @@ namespace SaveOurShip2
 	}
 
 	// Additional null checks when loading
-	[HarmonyPatch(typeof(Patch_WorldHandling), "AllAerialVehicles_AliveOrDead")]
+	[HarmonyPatch(typeof(Patch_MapPawns), "AllAerialVehicles_AliveOrDead")]
 	public static class AllAerialVehiclesOnLoad
 	{
 		public static bool Prefix()


### PR DESCRIPTION
arrived to Steam, so needs urgent fix.
Maybe that patch can be removed, but that requires extensive testing.