### PR TITLE
Update patch_dlc.xml

### DIFF
--- a/1.6/Patches/patch_dlc.xml
+++ b/1.6/Patches/patch_dlc.xml
@@ -825,6 +825,13 @@
 						<DecompressionResistance>0.75</DecompressionResistance>
 					</value>
 				</li>
+				<!-- Archotech Skin -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/HediffDef[defName="SoSArchotechSkin"]/stages/li</xpath>
+					<value>
+						<preventVacuumBurns>true</preventVacuumBurns>
+					</value>
+				</li>
 				<!-- Odyssey Space Headgear -->
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[defName="Apparel_VacsuitHelmet"]/equippedStatOffsets[not(DecompressionResistance)]</xpath>


### PR DESCRIPTION
Proper fix for adding <preventVacuumBurns> to archotech skin. Will now check if Odyssey is active before adding the value to the HeDiff.