### PR TITLE
Update Buildings_Joy.xml

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Joy.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Joy.xml
@@ -241,9 +241,12 @@
     <building>
       <joyKind>Telescope</joyKind>
     </building>
+	<researchPrerequisites>
+      <li>ComplexFurniture</li>
+    </researchPrerequisites>
     <costList>
       <Plasteel>25</Plasteel>
-      <ComponentSpacer>1</ComponentSpacer>
+      <ComponentIndustrial>1</ComponentIndustrial>
     </costList>
     <statBases>
       <MaxHitPoints>75</MaxHitPoints>


### PR DESCRIPTION
Added complex furniture as a research prerequisite so tribals don't have access to telescopes right off the bat. Adjusted cost to 1 component instead of 1 advanced component. For comparison, if telescopes were buildable they cost 1 component and 50 Steel. The Space Telescope costs 1 component and 25 Plasteel.