### PR TITLE
Update patch_dlc.xml

### DIFF
--- a/1.6/Patches/patch_dlc.xml
+++ b/1.6/Patches/patch_dlc.xml
@@ -808,7 +808,6 @@
 					<xpath>Defs/GeneDef[defName="VacuumResistance_Total"]/statOffsets</xpath>
 					<value>
 						<HypoxiaResistance>1</HypoxiaResistance>
-						<DecompressionResistance>1</DecompressionResistance>
 					</value>
 				</li>
 				<!-- Vacuum Resistant Gene -->


### PR DESCRIPTION
Removed Decompression resistance from the breathless gene. Nothing in the gene suggests it would have helped with decompression since everything else related to it are benefits for the pawn not having to breathe. Was a mistake adding it since it dilutes decompression / hypoxia resistance.