### PR TITLE
Allow gravships to land on SOS 2 space terrain. They don't need to touch

### DIFF
--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -5656,11 +5656,37 @@ namespace SaveOurShip2
 
 	// Odyssey
 	[HarmonyPatch(typeof(GravshipUtility), "AbandonMap")]
-	public class NoSpaceMapDestruction
+	public static class NoSpaceMapDestruction
 	{
 		public static bool Prefix(Map map)
 		{
 			return !map.IsSpace();
+		}
+	}
+
+	[HarmonyPatch(typeof(Designator_MoveGravship), "IsValidCell")]
+	public class CanLandOnSOS2Space
+	{
+		public static void Postfix(IntVec3 cell, Map map, ref AcceptanceReport __result)
+		{
+			if((__result.Reason == "GravshipBlockedByTerrain".Translate(cell.GetTerrain(map)) &&
+				(map.terrainGrid.TerrainAt(cell) == ResourceBank.TerrainDefOf.EmptySpace)))
+			{
+				__result = AcceptanceReport.WasAccepted;
+			}
+
+		}
+	}
+
+	[HarmonyPatch(typeof(GenConstruct), "CanBuildOnTerrain")]
+	public static class CanBuildGravPanelsInSOS2Space
+	{
+		public static void Postfix(BuildableDef entDef, IntVec3 c, Map map, ref bool __result)
+		{
+			if (!__result && c.GetTerrain(map) == ResourceBank.TerrainDefOf.EmptySpace && entDef == TerrainDefOf.Substructure)
+			{
+				__result = !map.thingGrid.ThingsListAt(c).Any(t => t is Building);
+			}
 		}
 	}
 

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -63,7 +63,7 @@
     </Reference>
     <Reference Include="SmashTools">
       <HintPath>..\..\..\Vehicle-Framework\1.6\Assemblies\SmashTools.dll</HintPath>
-      <Private>False</Private>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
@@ -93,7 +93,7 @@
     </Reference>
     <Reference Include="Vehicles">
       <HintPath>..\..\..\Vehicle-Framework\1.6\Assemblies\Vehicles.dll</HintPath>
-      <Private>False</Private>
+	  <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
solid ground in this case because of arriving to walkable space. Also allow building Gravship Substructure in SOS 2 space.