### PR TITLE
Odyssey compatibility: fixed gravship range becuse with SOS 2 it doesn't

### DIFF
--- a/1.6/Patches/patch_dlc.xml
+++ b/1.6/Patches/patch_dlc.xml
@@ -888,6 +888,20 @@
 						<li>WorldDrawLayer_MouseTile</li>
 					</value>
 				</li>
+				<!-- Gravship range x2.5. Compared to normal Odyssey playthrough, there is a need to return back home to continue building bigger ship
+					using resources obtained in Odyssy run. Theoretically could be 2x, but it is just too low by default -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="SmallThruster"]/comps/li[@Class="CompProperties_GravshipThruster"]/statOffsets/GravshipRange</xpath>
+					<value>
+						<GravshipRange>25</GravshipRange>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="LargeThruster"]/comps/li[@Class="CompProperties_GravshipThruster"]/statOffsets/GravshipRange</xpath>
+					<value>
+						<GravshipRange>40</GravshipRange>
+					</value>
+				</li>
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
just travel one way, but often needs to return back home to build more expensive spaceship with resources collected in gravship journey.