### PR TITLE
EVA Gear Vacuum Resistance Adjustments

### DIFF
--- a/1.6/Defs/ThingDefs_Misc/Apparel_Space.xml
+++ b/1.6/Defs/ThingDefs_Misc/Apparel_Space.xml
@@ -33,7 +33,7 @@
 			<WorkSpeedGlobal>-0.075</WorkSpeedGlobal>
 			<DecompressionResistance>0.75</DecompressionResistance>
 			<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.75</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.35</VacuumResistance>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>ApparelArmor</li>
@@ -112,7 +112,7 @@
 			<WorkSpeedGlobal>-0.075</WorkSpeedGlobal>
 			<DecompressionResistance>0.75</DecompressionResistance>
 			<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.75</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.35</VacuumResistance>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>ApparelArmor</li>
@@ -194,7 +194,7 @@
 			<ToxicEnvironmentResistance>1.0</ToxicEnvironmentResistance>
 			<HypoxiaResistance>1</HypoxiaResistance>
 			<DecompressionResistance>0.25</DecompressionResistance>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.25</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.7</VacuumResistance>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>ArmorHeadgear</li>
@@ -260,7 +260,7 @@
 			<ToxicEnvironmentResistance>1.0</ToxicEnvironmentResistance>
 			<HypoxiaResistance>1</HypoxiaResistance>
 			<DecompressionResistance>0.25</DecompressionResistance>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.25</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.7</VacuumResistance>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>ArmorHeadgear</li>
@@ -330,7 +330,7 @@
 			<WorkSpeedGlobal>-0.1</WorkSpeedGlobal>
 			<DecompressionResistance>0.75</DecompressionResistance>
 			<VacuumSpeedMultiplier>4</VacuumSpeedMultiplier>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.75</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.35</VacuumResistance>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>ApparelArmor</li>
@@ -433,7 +433,7 @@
 			<ToxicEnvironmentResistance>1.0</ToxicEnvironmentResistance>
 			<HypoxiaResistance>1</HypoxiaResistance>
 			<DecompressionResistance>0.25</DecompressionResistance>
-			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.25</VacuumResistance>
+			<VacuumResistance MayRequire="Ludeon.RimWorld.Odyssey">0.7</VacuumResistance>
 		</equippedStatOffsets>
 		<costList>
 			<ComponentSpacer>2</ComponentSpacer>


### PR DESCRIPTION
Adjusted vacuum resistance values on EVA gear so that people mixing different pieces of gear don't have trouble reaching 100% vacuum resistance.

All helmets are now 70% vacuum resistance.
All suits are now 35% vacuum resistance.

You should now reach 100% resistance if your mixing odyssey helmets and suits and if your mixing power armor helmet and suits.