### PR TITLE
Fixed EscapeShip quest site to be abandonable. Ti is now reached from

### DIFF
--- a/Source/1.6/ArrivalAction/AerialVehicleArrivalAction_LoadMapAndDefog.cs
+++ b/Source/1.6/ArrivalAction/AerialVehicleArrivalAction_LoadMapAndDefog.cs
@@ -30,7 +30,7 @@ namespace SaveOurShip2.Vehicles
             LongEventHandler.QueueLongEvent((Action)delegate
             {
                 Map map = GetOrGenerateMapUtility.GetOrGenerateMap(tile, null);
-                SOS2MapUtility.TryLinkMapToWorldObject(map, tile);
+                SOS2MapUtility.FixWorldObjectFaction(tile);
                 // CHANGE 1.6 - new hasMap parameter
                 MapLoaded(map, true);
                 FloodFillerFog.FloodUnfog(CellFinderLoose.TryFindCentralCell(map, 7, 10, (IntVec3 x) => !x.Roofed(map)), map);

--- a/Source/1.6/Building/Building_ShipSensor.cs
+++ b/Source/1.6/Building/Building_ShipSensor.cs
@@ -78,7 +78,7 @@ namespace SaveOurShip2
 					{
 						GetOrGenerateMapUtility.GetOrGenerateMap(target.WorldObject.Tile, target.WorldObject.def);
 						GenStep_Fog.UnfogMapFromEdge(observedMap.Map);
-						SOS2MapUtility.TryLinkMapToWorldObject(observedMap.Map, target.Tile);
+						SOS2MapUtility.FixWorldObjectFaction(target.Tile);
 					}, "GeneratingMap", false, delegate { });
 					return true;
 				}

--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -5319,6 +5319,15 @@ namespace SaveOurShip2
 		}
 	}
 
+	[HarmonyPatch(typeof(ArrivalAction_LoadMap), "Arrived")]
+	public static class SetQuestLandedShipFactionOnArrival
+	{
+		public static void Postfix(GlobalTargetInfo target)
+		{
+			SOS2MapUtility.FixWorldObjectFaction(target.Tile);
+		}
+	}
+
 	[HarmonyPatch(typeof(ThingOwnerUtility), "TryGetFixedTemperature")]
 	public static class WarmInsideShuttles
 	{

--- a/Source/1.6/SOS2MapUtility.cs
+++ b/Source/1.6/SOS2MapUtility.cs
@@ -37,15 +37,13 @@ namespace SaveOurShip2
 			return false;
 		}
 
-		public static void TryLinkMapToWorldObject(Map map, PlanetTile tile)
+		public static void FixWorldObjectFaction(PlanetTile tile)
 		{
-			// For now, issue was found with Escape Ship map due to that map not being linked to world object
-			// So, fixing onlyy that case for now
+			// The issue is it is possible to scan or to arrive to landed ship whithout it's world object faction set to player.
+			// Which needs to be fixed to make it abandonable.
 			WorldObject worldObject = Find.WorldObjects.ObjectsAt(tile).FirstOrDefault(t => true);
-			if (worldObject != null && worldObject.Faction != Faction.OfPlayer)
+			if (worldObject != null && worldObject.Faction != Faction.OfPlayer && worldObject.def.defName == "EscapeShip")
 			{
-				// Link map to Escap ship object sho that it gets "Home" icon and when selected on world map, there is Abadon option 
-				map.info.parent = (MapParent)worldObject;
 				worldObject.SetFaction(Faction.OfPlayer);
 			}
 		}


### PR DESCRIPTION
Framework rather than custom arrival action and only needs world object faction set, apparently linking with map is fixed in 1.6 base game. The patch to VF arrival action is to be removed if that stuff is implemented on Framwork side.