### PR TITLE
Manual Helmet Comp adding

### DIFF
--- a/1.6/Patches/patch_base.xml
+++ b/1.6/Patches/patch_base.xml
@@ -141,15 +141,24 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase" or @ParentName="ApparelArmorHelmetReconBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
+		<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
 		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase" or @ParentName="ApparelArmorHelmetReconBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
+			<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
 			<value>
 				<li>
 					<compClass>SaveOurShip2.CompEVA</compClass>
 				</li>
 			</value>
 		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_PowerArmorHelmet" or defName="Apparel_ArmorHelmetRecon"]/comps</xpath>
+		<value>
+		<li>
+			<compClass>SaveOurShip2.CompEVA</compClass>
+		</li>
+		</value>
 	</Operation>
 
 	<!-- EVA stats -->


### PR DESCRIPTION
No longer adds SaveOurShip2.CompEVA to parents of marine and recon helm. They are now added manually to prevent that pesky gunlink from inheriting.