### PR TITLE
Manual Update of Recon Parent Helms

### DIFF
--- a/1.6/Patches/patch_base.xml
+++ b/1.6/Patches/patch_base.xml
@@ -141,15 +141,24 @@
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase" or @ParentName="ApparelArmorHelmetReconBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
+		<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
 		<match Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase" or @ParentName="ApparelArmorHelmetReconBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
+			<xpath>Defs/ThingDef[@ParentName="ApparelArmorReconBase" or @ParentName="ApparelArmorPowerBase" or @ParentName="ApparelArmorHelmetPowerBase"]/comps[not(li/compClass="SaveOurShip2.CompEVA")]</xpath>
 			<value>
 				<li>
 					<compClass>SaveOurShip2.CompEVA</compClass>
 				</li>
 			</value>
 		</match>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetRecon"]/comps</xpath>
+		<value>
+		<li>
+			<compClass>SaveOurShip2.CompEVA</compClass>
+		</li>
+		</value>
 	</Operation>
 
 	<!-- EVA stats -->


### PR DESCRIPTION
Removed updating helms that inherit from parent recon to prevent gunlinks from getting the saveourship2 comp. Now any recon helmet that uses that parent has to be manually updated to receive the comp.