### PR TITLE
Ship vents and life support sysetems will work as powerful oxygen pumps

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -459,6 +459,10 @@
 			<li Class="SaveOurShip2.CompProps_ShipHeat">
 				<compClass>SaveOurShip2.CompShipHeat</compClass>
 			</li>
+			<li MayRequire="Ludeon.RimWorld.Odyssey" Class="CompProperties_OxygenPusher">
+				<requiresPower>true</requiresPower>
+				<airPerSecondPerHundredCells>0.09</airPerSecondPerHundredCells>
+			</li>
 			<li>
 				<compClass>CompColorable</compClass>
 			</li>
@@ -1781,6 +1785,10 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="SaveOurShip2.CompProps_LifeSupport"/>
 			<li Class="SaveOurShip2.CompProps_GraphicOnOff"/>
+			<li MayRequire="Ludeon.RimWorld.Odyssey" Class="CompProperties_OxygenPusher">
+				<requiresPower>true</requiresPower>
+				<airPerSecondPerHundredCells>2</airPerSecondPerHundredCells>
+			</li>
 		</comps>
 		<placeWorkers>
 			<li>SaveOurShip2.PlaceWorker_OnShipHull</li>
@@ -1840,6 +1848,10 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="SaveOurShip2.CompProps_LifeSupport"/>
 			<li Class="SaveOurShip2.CompProps_GraphicOnOff"/>
+			<li MayRequire="Ludeon.RimWorld.Odyssey" Class="CompProperties_OxygenPusher">
+				<requiresPower>true</requiresPower>
+				<airPerSecondPerHundredCells>1</airPerSecondPerHundredCells>
+			</li>
 		</comps>
 		<placeWorkers>
 			<li>SaveOurShip2.PlaceWorker_OnShipHull</li>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_ShipMech.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_ShipMech.xml
@@ -395,6 +395,10 @@
 			<li Class="SaveOurShip2.CompProps_ShipHeat">
 				<compClass>SaveOurShip2.CompShipHeat</compClass>
 			</li>
+			<li MayRequire="Ludeon.RimWorld.Odyssey" Class="CompProperties_OxygenPusher">
+				<requiresPower>true</requiresPower>
+				<airPerSecondPerHundredCells>0.09</airPerSecondPerHundredCells>
+			</li>
 			<li>
 				<compClass>CompColorable</compClass>
 			</li>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_ShipTechArcho.xml
@@ -424,6 +424,10 @@
 			<li Class="SaveOurShip2.CompProps_ResearchUnlock">
 				<unlock>ArchotechUplink</unlock>
 			</li>
+			<li MayRequire="Ludeon.RimWorld.Odyssey" Class="CompProperties_OxygenPusher">
+				<requiresPower>true</requiresPower>
+				<airPerSecondPerHundredCells>0.18</airPerSecondPerHundredCells>
+			</li>
 			<li>
 				<compClass>CompColorable</compClass>
 			</li>

--- a/Source/1.6/Building/Building_ShipAirlock.cs
+++ b/Source/1.6/Building/Building_ShipAirlock.cs
@@ -15,7 +15,9 @@ namespace SaveOurShip2
 {
 	public class Building_ShipAirlock : Building_Door
 	{
-		public override bool ExchangeVacuum => false;
+		// Very similar to base door function, overiding to avoid dealing with
+		// Harmony patches to base door function.
+		public override bool ExchangeVacuum => Open;
 
 		List<Building> extenders = new List<Building>();
 

--- a/Source/1.6/Building/Building_ShipVent.cs
+++ b/Source/1.6/Building/Building_ShipVent.cs
@@ -24,6 +24,7 @@ namespace SaveOurShip2
 
 		public override void TickRare()
 		{
+			base.TickRare();
 			if (this.compPowerTrader.PowerOn)
 			{
 				bool flag = false; //operating at high power

--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -5790,6 +5790,40 @@ namespace SaveOurShip2
         }
 	}
 
+	[HarmonyPatch(typeof(CompOxygenPusher), "CompTickRare")]
+	// Resolve the design difference between original ship heat vents being located in the wall, 
+	// while Odyssey oxygen pumps being attached to the wall, but located in the room.
+	public static class GetRoomForShipVent
+	{
+		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+		{
+			MethodInfo originalGetRoom =
+				AccessTools.Method(typeof(RegionAndRoomQuery), nameof(RegionAndRoomQuery.GetRoom));
+			foreach (CodeInstruction instruction in instructions)
+			{
+				if (instruction.Calls(originalGetRoom))
+				{
+					yield return new CodeInstruction(opcode: OpCodes.Call,
+						operand: AccessTools.Method(typeof(GetRoomForShipVent),
+						nameof(GetRoomForShipVent.GetRoomFixed)));
+				}
+				else
+				{
+					yield return instruction;
+				}
+			}
+		}
+		public static Room GetRoomFixed(this Thing thing, RegionType allowedRegionTypes = RegionType.Set_All)
+		{
+			Log.Warning("Fixed Get room used");
+			if (thing is Building_ShipVent)
+            {
+				return (thing as Building_ShipVent).ventTo.GetRoom(thing.Map);
+            }
+			return thing.GetRoom(allowedRegionTypes);
+		}
+	}
+
 	/*[HarmonyPatch(typeof(ActiveDropPod),"PodOpen")]
 	public static class ActivePodFix{
 		public static bool Prefix (ref ActiveDropPod __instance)


### PR DESCRIPTION
in Odyssey space. So that player doesn't have to add duplicate "anti-vacuum" systems when visiting such maps. Open ship airlocks will now transfer vacuum, otherwise player will need a vent in EVERY room separated by ship airlock, which is too much. Because of how powerful vents are in pumping oxygen, not having double door at the ship exit, aka "true airlock" should be manageable.
New transpiler handles the difference between in-room hardware attached to walls vs in-wall hardware.