### PR TITLE
Odyssey-related tuning so that Ody players get what they ask for:

### DIFF
--- a/1.6/Languages/English/Keyed/Gameplay.xml
+++ b/1.6/Languages/English/Keyed/Gameplay.xml
@@ -557,6 +557,10 @@
 	<SoS.EnergyShieldStatusLabel>Shield</SoS.EnergyShieldStatusLabel>
 	<SoS.EnergyShieldStatusDesc>{0} / {1}</SoS.EnergyShieldStatusDesc>
 
+	<SoS.Sensor.ConfimObserve>Warning! Passively observing quest maps and sites for a prolonged time without sending player pawns there via ship or shuttle can cause pawn logic to break, quest logic to break, etc.
+Observing maps before landing ship there should be fine.
+Are you sure you want to proceed?</SoS.Sensor.ConfimObserve>
+
 	<!-- Ship combat stuff -->
 	<SoS.Combat.MapShipInfo>SOS2 {0} | Ships: {1} | Cells: {2}</SoS.Combat.MapShipInfo>
 

--- a/Source/1.6/Building/Building_ShipSensor.cs
+++ b/Source/1.6/Building/Building_ShipSensor.cs
@@ -70,22 +70,29 @@ namespace SaveOurShip2
 			PossiblyDisposeOfObservedMap();
 			if (target.WorldObject != null && target.WorldObject is MapParent p)
 			{
-				if (ShipInteriorMod2.allowedToObserve.Contains(p.def.defName))
+				observedMap = (MapParent)target.WorldObject;
+				Action observeAction = delegate
 				{
-					observedMap = (MapParent)target.WorldObject;
-					// GeneratingMap translation key is from base game
-					LongEventHandler.QueueLongEvent(delegate
+					GetOrGenerateMapUtility.GetOrGenerateMap(target.WorldObject.Tile, target.WorldObject.def);
+					GenStep_Fog.UnfogMapFromEdge(observedMap.Map);
+					SOS2MapUtility.FixWorldObjectFaction(target.Tile);
+				};
+				if (!ShipInteriorMod2.allowedToObserve.Contains(p.def.defName))
+				{
+					Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(TranslatorFormattedStringExtensions.Translate("SoS.Sensor.ConfimObserve"), delegate
 					{
-						GetOrGenerateMapUtility.GetOrGenerateMap(target.WorldObject.Tile, target.WorldObject.def);
-						GenStep_Fog.UnfogMapFromEdge(observedMap.Map);
-						SOS2MapUtility.FixWorldObjectFaction(target.Tile);
-					}, "GeneratingMap", false, delegate { });
+						// GeneratingMap translation key is from base game
+						LongEventHandler.QueueLongEvent(observeAction, "GeneratingMap", false, delegate { });
+					}
+					));
+					// Actual "result" is behind delegate passed to dialog, but for now can simplify things and just return true here becasue sensor logic
+					// doesn't rely on that result.
 					return true;
 				}
 				else
                 {
-					Messages.Message("SoSNoMapObserve".Translate(), MessageTypeDefOf.RejectInput);
-					return false;
+					LongEventHandler.QueueLongEvent(observeAction, "GeneratingMap", false, delegate { });
+					return true;
                 }
 			}
 			else if (target.WorldObject == null && !Find.World.Impassable(target.Tile))

--- a/Source/1.6/Comp/ShipMapComp.cs
+++ b/Source/1.6/Comp/ShipMapComp.cs
@@ -1658,13 +1658,20 @@ namespace SaveOurShip2
 			{
 				if (MapEnginePower > 0)
 				{
+					float transitionSpeed = 0.1f;
+					// Faster transition for map hopping playstyle when takeof and landing happens rather often
+					// vs "classic" playsyle of launching to orbit once in a playthrough an then doing everything on space map
+					if (ModsConfig.OdysseyActive)
+                    {
+						transitionSpeed *= 1.7f;
+                    }
 					if (Heading > 0) //ascend
 					{
-						Altitude += 0.1f * MapEnginePower;
+						Altitude += transitionSpeed * MapEnginePower;
 					}
 					else if (Heading < 0) //descend
 					{
-						Altitude -= 0.1f * MapEnginePower;
+						Altitude -= transitionSpeed * MapEnginePower;
 					}
 				}
 				else if (Altitude > ShipInteriorMod2.altitudeLand) //descend unless in stable or startup altitude
@@ -1790,7 +1797,7 @@ namespace SaveOurShip2
 					{
 						foreach (Building b in ship.OuterNonShipWalls())
 						{
-							if (Rand.Chance(0.5f))
+							if (Rand.Chance(0.5f) && b.Stuff == ThingDefOf.WoodLog)
 								buildings.Add(b);
 						}
 					}

--- a/Source/1.6/Events/IncidentWorker_ShipCombat.cs
+++ b/Source/1.6/Events/IncidentWorker_ShipCombat.cs
@@ -13,6 +13,12 @@ namespace SaveOurShip2
 			if (!mapComp.IsPlayerShipMap || mapComp.ShipMapState != ShipMapState.nominal || mapComp.NextTargetMap != null || ModSettings_SoS.frequencySoS == 0 || Find.TickManager.TicksGame < mapComp.LastAttackTick + 300000 / ModSettings_SoS.frequencySoS)
 				return false;
 
+			// Can't be attacked if just got to space, for interoperability with Odyssey
+			if (Find.TickManager.TicksGame - map.generationTick < GenDate.TicksPerHour * 3)
+            {
+				return false;
+            }
+
 			foreach (Building_ShipCloakingDevice cloak in mapComp.Cloaks)
 			{
 				if (cloak.active)

--- a/Source/1.6/ShipInteriorMod2.cs
+++ b/Source/1.6/ShipInteriorMod2.cs
@@ -141,7 +141,7 @@ namespace SaveOurShip2
 		public const float crittersleepBodySize = 0.7f;
 		public const float pctFuelLocal = 0.0f;
 		public const float pctFuelMap = 0.05f;
-		public const float pctFuelSpace = 0.5f; //check is 1 since we dont want ships to crash right after takeoff
+		public const float pctFuelSpace = 0.23f; //check is 1 since we dont want ships to crash right after takeoff
 		public const float pctFuelLand = 0.1f;
 
 		public static bool loadedGraphics = false;


### PR DESCRIPTION
- Can observe settlements and quest sites. Warning message will be shown if it can cause issues.
- Ship takeoff is now roughly 2x cheaper.
- Ship takeoff will take less time when Odyssey is enabled.
- After getting to orbit (new player space map), normal non-bounty-hunters enemies won't attack player for 3 hours.