### PR TITLE
Update Buildings_ShuttleVF.xml Collision

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_ShuttleVF.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_ShuttleVF.xml
@@ -97,7 +97,8 @@
 		</drawProperties>
 		
 		<properties>
-			
+			<pawnCollisionMultiplier>0.2</pawnCollisionMultiplier>
+			<pawnCollisionRecoilMultiplier>0.5</pawnCollisionRecoilMultiplier>	
 			<roles>
 				<li>
 					<key>pilot</key>
@@ -694,6 +695,8 @@
 		</soundOneShotsOnEvent>
 		
 		<properties>
+			<pawnCollisionMultiplier>0.2</pawnCollisionMultiplier>
+			<pawnCollisionRecoilMultiplier>0.5</pawnCollisionRecoilMultiplier>
 			<roles>
 				<li>
 					<key>pilot</key>
@@ -1377,6 +1380,8 @@
 		</soundOneShotsOnEvent>
 		
 		<properties>
+			<pawnCollisionMultiplier>0.2</pawnCollisionMultiplier>
+			<pawnCollisionRecoilMultiplier>0.5</pawnCollisionRecoilMultiplier>
 			<roles>
 				<li>
 					<key>pilot</key>
@@ -2206,6 +2211,8 @@
 		</soundOneShotsOnEvent>
 		
 		<properties>
+			<pawnCollisionMultiplier>0.2</pawnCollisionMultiplier>
+			<pawnCollisionRecoilMultiplier>0.5</pawnCollisionRecoilMultiplier>
 			<roles>
 				<li>
 					<key>pilot</key>


### PR DESCRIPTION
Collision damage is now 0.2x multiplier, down from 0.5. Field added for recoil, but default value unchanged.