### PR TITLE
Fix Airlock pathfinding issue: that is done in non-main threads, so it

### DIFF
--- a/Source/1.6/Building/Building_ShipAirlock.cs
+++ b/Source/1.6/Building/Building_ShipAirlock.cs
@@ -95,7 +95,8 @@ namespace SaveOurShip2
 			//enemy pawns can pass through their doors if outside or with EVA when player is present
 			if (p.Map.IsSpace() && p.Faction != Faction.OfPlayer && Outerdoor())
 			{
-				if (!(ShipInteriorMod2.ExposedToOutside(p.GetRoom()) || (p.CanSurviveVacuum() && (mapComp.ShipMapState != ShipMapState.inCombat || p.Map.mapPawns.AnyColonistSpawned)) || p.CurJobDef == ResourceBank.JobDefOf.FleeVacuum))
+				bool colonistPresent = p.Map.mapPawns.AllPawnsSpawned.Any(pawn => pawn.Faction == Faction.OfPlayer);
+				if (!(ShipInteriorMod2.ExposedToOutside(p.GetRoom()) || (p.CanSurviveVacuum() && (mapComp.ShipMapState != ShipMapState.inCombat || colonistPresent)) || p.CurJobDef == ResourceBank.JobDefOf.FleeVacuum))
 					return false;
 			}
 			Lord lord = p.GetLord();


### PR DESCRIPTION
can't acces normal map pawns. Changed to accessing read-only list from map pawns, which is allowed.