### PR TITLE
Fix orbital ships cleanup: Odyssey just removes all passing ships for

### DIFF
--- a/Source/1.6/HarmonyCustomPatches.cs
+++ b/Source/1.6/HarmonyCustomPatches.cs
@@ -11,14 +11,19 @@ using HarmonyLib;
 
 namespace SaveOurShip2
 {
-	// Here go omplicated things like patches to delegates requiring manual method search rather than simple annotation
+	// Here go complicated things like patches to delegates requiring manual method search rather than simple annotation
 	public static class HarmonyCustomPatches
 	{
 		public static void Apply(Harmony harmony)
 		{
-			ApplyGravshipTargetingPatch(harmony);
+			GravshipTargetingPatch.Apply(harmony);
+			DontCleanShipsPatch.Apply(harmony);
 		}
-		public static void ApplyGravshipTargetingPatch(Harmony harmony)
+	}
+
+	public static class GravshipTargetingPatch
+	{
+		public static void Apply(Harmony harmony)
 		{
 			const string innerClassName = "<>c__DisplayClass14_0";
 			const string methodName = "<StartChoosingDestination_NewTemp>b__0";
@@ -26,7 +31,7 @@ namespace SaveOurShip2
 			var innerType = types.FirstOrDefault(type => type.Name == innerClassName);
 			List<MethodInfo> innerMethods = innerType.GetDeclaredMethods();
 			MethodInfo delegateValidateTarget = innerMethods.FirstOrDefault(method => method.Name == methodName);
-			harmony.Patch(delegateValidateTarget, prefix: new HarmonyMethod(typeof(HarmonyCustomPatches), nameof(ValidateTargetPrefix)));
+			harmony.Patch(delegateValidateTarget, prefix: new HarmonyMethod(typeof(GravshipTargetingPatch), nameof(ValidateTargetPrefix)));
 		}
 
 		// Delegate validating gravship target will disallow sending it to the pap participating in ship battle
@@ -48,6 +53,51 @@ namespace SaveOurShip2
 				}
 			}
 			return true;
+		}
+	}
+	public static class DontCleanShipsPatch
+	{
+		public static void Apply(Harmony harmony)
+		{
+			const string innerClassName = "<>c__DisplayClass5_1";
+			const string methodName = "<RequestOrbitalTraderOption>b__1";
+			Type[] types = typeof(FactionDialogMaker).GetNestedTypes(AccessTools.all);
+			var innerType = types.FirstOrDefault(type => type.Name == innerClassName);
+			List<MethodInfo> innerMethods = innerType.GetDeclaredMethods();
+			MethodInfo delegateDialogOption = innerMethods.FirstOrDefault(method => method.Name == methodName);
+			harmony.Patch(delegateDialogOption, prefix: new HarmonyMethod(typeof(DontCleanShipsPatch), nameof(CallOrbitalTraderDialogOptionPrefix)),
+				postfix: new HarmonyMethod(typeof(DontCleanShipsPatch), nameof(CallOrbitalTraderDialogOptionPostfix)));
+			harmony.Patch(AccessTools.Method(typeof(PassingShip), nameof(PassingShip.Depart)),
+				prefix: new HarmonyMethod(typeof(DontCleanShipsPatch), nameof(DepartPrefix)));
+			harmony.Patch(AccessTools.Method(typeof(FactionDialogMaker), nameof(FactionDialogMaker.RequestOrbitalTraderOption)),
+				prefix: new HarmonyMethod(typeof(DontCleanShipsPatch), nameof(DialogMakerPrefix)));
+		}
+
+		// Detect if Depart is called from Odyssey dialog for calling orbital traders.
+		// And do not do depart if that is done on space map.
+		private static bool cleaningShipsInOdysseyDialog = false;
+		private static Map traderDialogMap = null;
+		public static bool CallOrbitalTraderDialogOptionPrefix()
+		{
+			if (traderDialogMap != null && traderDialogMap.IsSpace())
+			{
+				cleaningShipsInOdysseyDialog = true;
+			}
+			return true;
+		}
+		public static void CallOrbitalTraderDialogOptionPostfix()
+		{
+			cleaningShipsInOdysseyDialog = false;
+		}
+
+		public static bool DepartPrefix()
+        {
+			return !cleaningShipsInOdysseyDialog;
+		}
+		public static void DialogMakerPrefix(Map map)
+        {
+			// Save the map here so that don't have to dig it from __locals of the class generated for delegate
+			traderDialogMap = map;
 		}
 	}
 }


### PR DESCRIPTION
current map when calling for orbital faction trader. This action won't be applied to space maps so that scanned ships aren't lost.