### PR TITLE
In 1.6, assigning duties only in LortToil.UpdateAllDuties override isn't

### DIFF
--- a/Source/1.6/Jobs/LordToil_DefendShip.cs
+++ b/Source/1.6/Jobs/LordToil_DefendShip.cs
@@ -27,5 +27,12 @@ namespace SaveOurShip2
 				lord.ownedPawns[i].mindState.duty = new PawnDuty(ResourceBank.DutyDefOf.SoSDefendShip, baseCenter);
 			}
 		}
-	}
+        public override void Notify_PawnJobDone(Pawn p, JobCondition condition)
+        {
+			if(p.mindState.duty == null)
+			{
+                p.mindState.duty = new PawnDuty(ResourceBank.DutyDefOf.SoSDefendShip, baseCenter);
+            }
+        }
+    }
 }


### PR DESCRIPTION
enough.
To fix enemy pawns not having duty errors after they've tried to board shuttle but aborted due to shuttle destruction, Defend ship duty is now restored if needed when job ended.