### PR TITLE
Remove incorecly working ReturnToShip command for out of combat player

### DIFF
--- a/1.6/Languages/English/Keyed/Gameplay.xml
+++ b/1.6/Languages/English/Keyed/Gameplay.xml
@@ -381,6 +381,7 @@
 	<SoS.ShuttleMissionFloatIntercept>Mission: Intercept Torpedoes/Fighters</SoS.ShuttleMissionFloatIntercept>
 	<SoS.ShuttleMissionFloatStrafe>Mission: Strafe Enemy Ship</SoS.ShuttleMissionFloatStrafe>
 	<SoS.ShuttleMissionFloatTorpedo>Mission: Torpedo Enemy Ship</SoS.ShuttleMissionFloatTorpedo>
+	<!-- Return to ship from some out of combat location. Not used. Standard Vehicle Framework option to zoom in and chose location isa used instead -->
 	<SoS.ShuttleMissionFloatReturn>Return to Ship</SoS.ShuttleMissionFloatReturn>
 	<SoS.ShuttleRetreat>Your shuttle is retreating due to damaged hull!</SoS.ShuttleRetreat>
 	<SoS.EnemyShuttleRetreat>Enemy shuttle is retreating due to damaged hull!</SoS.EnemyShuttleRetreat>

--- a/Source/1.6/Vehicles/ShuttleTakeoff.cs
+++ b/Source/1.6/Vehicles/ShuttleTakeoff.cs
@@ -55,8 +55,12 @@ namespace SaveOurShip2.Vehicles
 					}
 					else //target is player ship
 					{
-						yield return ArrivalOption_ReturnFromEnemy(target.Tile);
-					}
+                        foreach (ArrivalOption option in base.GetArrivalOptions(target))
+                        {
+                            yield return option;
+                        }
+                        yield break;
+                    }
 				}
 			}
             List<ArrivalOption> baseOptions = new List<ArrivalOption>(base.GetArrivalOptions(target));


### PR DESCRIPTION
shuttles in favor of using standard Vehicle Framework command.