### PR TITLE
Enable Archotech Jaw as archotech gift. Was disabled long ago due to

### DIFF
--- a/1.6/Defs/Misc/ArchotechGifts.xml
+++ b/1.6/Defs/Misc/ArchotechGifts.xml
@@ -67,11 +67,11 @@
 	<thing>SoSArchotechNose</thing>
   </SaveOurShip2.ArchoGiftDef>
   
-  <!--SaveOurShip2.ArchoGiftDef>
+  <SaveOurShip2.ArchoGiftDef>
     <defName>ArchotechJaw</defName>
 	<research>SoSArchotechOrgans</research>
 	<thing>SoSArchotechJaw</thing>
-  </SaveOurShip2.ArchoGiftDef-->
+  </SaveOurShip2.ArchoGiftDef>
   
   <SaveOurShip2.ArchoGiftDef>
     <defName>ArchotechHeart</defName>


### PR DESCRIPTION
causing disfigured debuff on pawns.