### PR TITLE
Always show land gizmo, even when there are no maps to land on. so that

### DIFF
--- a/1.6/Languages/English/Keyed/Gameplay.xml
+++ b/1.6/Languages/English/Keyed/Gameplay.xml
@@ -198,8 +198,11 @@
 	<SoS.MoveFailFuel>Not enough fuel to move ship, required {0} fuel</SoS.MoveFailFuel>
 	<SoS.MoveFailFaction>Ship from another faction next to target area. Move aborted.</SoS.MoveFailFaction>
 	<SoS.MoveFailCombat>Main ship map is in battle.</SoS.MoveFailCombat>
-	<SoS.Land>Land ship</SoS.Land>
-	<SoS.LandDesc>Land this ship near </SoS.LandDesc>
+	<SoS.Land>Land ship ({0})</SoS.Land>
+	<SoS.LandDesc>Land this ship near {0}</SoS.LandDesc>
+	<!-- Used in 2 above strings as key filler when there in actual location to land available -->
+	<SoS.LandSomewhere>somewhere</SoS.LandSomewhere>
+	<SoS.LandNoTargetTile>There is no surface map to land on. Observe planet surface tile with ship scanner or science console.</SoS.LandNoTargetTile>
 	<SoS.Rebuild>Rebuild ship parts</SoS.Rebuild>
 	<SoS.RebuildDesc>Places blueprints for destroyed buildings on this ship.</SoS.RebuildDesc>
 	<SoS.BridgeConnectTooltip>Bridge is not connected! Make sure this is hooked up to both heat and power networks.</SoS.BridgeConnectTooltip>

--- a/Source/1.6/Building/Building_ShipBridge.cs
+++ b/Source/1.6/Building/Building_ShipBridge.cs
@@ -826,6 +826,21 @@ namespace SaveOurShip2
 							if ((!m.IsSpace() && !m.IsTempIncidentMap) || (ckActive && m != Map))
 								landableMaps.Add(m);
 						}
+						if (landableMaps.Empty())
+						{
+							string targetPlaceholder = TranslatorFormattedStringExtensions.Translate("SoS.LandSomewhere");
+							Command_Action landShipDisabled = new Command_Action
+							{
+								groupable = false,
+								action = delegate { },
+								defaultLabel = TranslatorFormattedStringExtensions.Translate("SoS.Land", targetPlaceholder),
+								defaultDesc = TranslatorFormattedStringExtensions.Translate("SoS.LandDesc", targetPlaceholder),
+								icon = ContentFinder<Texture2D>.Get("UI/Planet_Landing_Icon")
+							};
+                            landShipDisabled.Disable();
+                            landShipDisabled.disabledReason = TranslatorFormattedStringExtensions.Translate("SoS.LandNoTargetTile");
+							yield return landShipDisabled;
+                        }
 						foreach (Map m in landableMaps)
 						{
 							Command_Action landShip = new Command_Action
@@ -835,8 +850,8 @@ namespace SaveOurShip2
 								{
 									ShipInteriorMod2.UnDockWarning(delegate { mapComp.MoveToMap = m; Ship.CreateShipSketchIfFuelPct(ShipInteriorMod2.pctFuelLand, m, 0, true); }, mapComp, shipIndex);
 								},
-								defaultLabel = TranslatorFormattedStringExtensions.Translate("SoS.Land") + " (" + m.Parent.Label + ")",
-								defaultDesc = TranslatorFormattedStringExtensions.Translate("SoS.LandDesc") + m.Parent.Label,
+								defaultLabel = TranslatorFormattedStringExtensions.Translate("SoS.Land", m.Parent.Label),
+								defaultDesc = TranslatorFormattedStringExtensions.Translate("SoS.LandDesc", m.Parent.Label),
 								icon = ContentFinder<Texture2D>.Get("UI/Planet_Landing_Icon")
 							};
 							if (ShipCountdown.CountingDown || !Ship.HasPilotRCSAndFuel(ShipInteriorMod2.pctFuelLand, false))


### PR DESCRIPTION
new players can learn to scan map before landing.
Also, fixed hardcoded word order in land command and its description.