### PR TITLE
Make notoriety really visible with permanent alert visible on all maps.

### DIFF
--- a/1.6/Languages/English/Keyed/Gameplay.xml
+++ b/1.6/Languages/English/Keyed/Gameplay.xml
@@ -467,6 +467,11 @@
 	<SoS.SatelliteRepair>Repair</SoS.SatelliteRepair>
 	<SoS.SatelliteHack>Hack</SoS.SatelliteHack>
 
+	<!-- notorietuy alert -->
+	<SoS.Alert.NotoriertyLabel>Notoriety: {0}</SoS.Alert.NotoriertyLabel>
+	<SoS.Alert.NotoriertyLowDesc>Because of pirating trade ships and/or because of using Orbital Bombardment (submod), player ship got notorious. Not too much yet, but continued piracy or bombardment will make it higher and attract bounty hunters.</SoS.Alert.NotoriertyLowDesc>
+	<SoS.Alert.NotoriertyHighDesc>Because of pirating trade ships and/or because of using Orbital Bombardment (submod), player ship got very notorious and is chased by bounty hunters. Attacks will happen roughly evey {0} days.</SoS.Alert.NotoriertyHighDesc>
+
 	<!-- This scetion and lower were added during major translation upgrade -->
 	<!-- Archotech and endgame stuff -->
 	<SoS.ArchotechIdeoKeep>Discover the truth of {0}</SoS.ArchotechIdeoKeep>

--- a/Source/1.6/Alert/AlertNotoriety.cs
+++ b/Source/1.6/Alert/AlertNotoriety.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using UnityEngine;
+using Verse;
+using RimWorld;
+using RimWorld.Planet;
+
+namespace SaveOurShip2
+{
+	// Becase base game creates one instannce of all lert leaf subclasses, 
+	// got to make 2 different classes for player dodge chance and enemy dodge chance
+	public class AlertNotoriety : Alert
+	{
+        public AlertNotoriety()
+			: base()
+		{
+		}
+
+		public override AlertReport GetReport()
+		{
+			if (ShipInteriorMod2.WorldComp.PlayerFactionBounty <= 0)
+			{
+				return false;
+			}
+			Map map = ShipInteriorMod2.FindPlayerShipMap();
+			if (map != null)
+			{
+				ShipMapComp mapComp = map.GetComponent<ShipMapComp>();
+				IEnumerable<SpaceShipCache> ships = mapComp.ShipsOnMap.Values.Where(s => !s.IsWreck);
+				SpaceShipCache flagship = ships.MaxBy(s => s.MassActual);
+				List<Thing> culprits = new List<Thing>{ flagship.Core };
+                return AlertReport.CulpritsAre(culprits);
+			}
+			return true;
+		}
+
+        public override string GetLabel()
+		{
+			return TranslatorFormattedStringExtensions.Translate("SoS.Alert.NotoriertyLabel", ShipInteriorMod2.WorldComp.PlayerFactionBounty);
+		}
+
+        public override TaggedString GetExplanation()
+		{
+			if(ShipInteriorMod2.WorldComp.NotorietyActive)
+			{
+                return TranslatorFormattedStringExtensions.Translate("SoS.Alert.NotoriertyHighDesc", GenDate.TicksToDays(ShipInteriorMod2.WorldComp.TicksBetweenNotorietyAttacks).ToString("F1"));
+            }
+			else
+			{
+				return TranslatorFormattedStringExtensions.Translate("SoS.Alert.NotoriertyLowDesc");
+            }
+		}
+	}
+}
+

--- a/Source/1.6/Comp/ShipMapComp.cs
+++ b/Source/1.6/Comp/ShipMapComp.cs
@@ -1801,8 +1801,8 @@ namespace SaveOurShip2
 						if (IsPlayerShipMap)
 						{
 							// Check for bounty hunters attack
-							if (ShipInteriorMod2.WorldComp.PlayerFactionBounty > 20 && tick - LastBountyRaidTick > Mathf.Max(600000f / Mathf.Sqrt(ShipInteriorMod2.WorldComp.PlayerFactionBounty), 60000f))
-							{
+							if (ShipInteriorMod2.WorldComp.NotorietyActive && tick - LastBountyRaidTick > ShipInteriorMod2.WorldComp.TicksBetweenNotorietyAttacks)
+                            {
 								LastBountyRaidTick = tick;
 								Building_ShipBridge bridge = MapRootListAll.FirstOrDefault();
 								if (bridge != null)

--- a/Source/1.6/Comp/ShipWorldComp.cs
+++ b/Source/1.6/Comp/ShipWorldComp.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using UnityEngine;
+using Verse;
 using RimWorld;
 using RimWorld.Planet;
 using System.Collections.Generic;
@@ -84,8 +85,33 @@ namespace SaveOurShip2
 				Log.Warning("SOS2: Insect faction not found! SOS2 gameplay experience will be affected.");
 		}
 
-		// Will show that letter once per save in order not to annoy players
-		private bool difficultyLetterShown = false;
+		public bool NotorietyActive
+		{
+			get
+			{
+				return PlayerFactionBounty > 20;
+			}
+		}
+		public int TicksBetweenNotorietyAttacks
+        {
+            get
+            {
+                // Updated formula: bounty hunters attack evry (15 days / Sqrt(notoriety)) with min notoriety 20 causing attachs every ~ 3.4 days,
+				// every 2 days at 55 notoriety, every 1.5 days at 100 notoriety
+                return (int)Mathf.Max((float)GenDate.TicksPerDay * 15 / Mathf.Sqrt(PlayerFactionBounty), (float)GenDate.TicksPerDay);
+            }
+        }
+
+		public int BountyPayment
+		{
+			get
+			{
+				return 1250 * PlayerFactionBounty;
+			}
+		}
+
+        // Will show that letter once per save in order not to annoy players
+        private bool difficultyLetterShown = false;
 		public override void WorldComponentTick()
 		{
 			if (Find.TickManager.TicksGame % GenTicks.TickRareInterval == 0)

--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -1782,18 +1782,20 @@ namespace SaveOurShip2
 				//pay bounty, gray if not enough money
 				if (bounty > 1)
 				{
-					DiaOption diaOption3 = new DiaOption(TranslatorFormattedStringExtensions.Translate("SoS.TradePayBounty", 2500 * bounty));
+					int bountyPayment = ShipInteriorMod2.WorldComp.BountyPayment;
+                    DiaOption diaOption3 = new DiaOption(TranslatorFormattedStringExtensions.Translate("SoS.TradePayBounty", bountyPayment));
+
 					diaOption3.action = delegate
 					{
-						TradeUtility.LaunchThingsOfType(ThingDefOf.Silver, 2500 * bounty, __instance.Map, null);
+						TradeUtility.LaunchThingsOfType(ThingDefOf.Silver, bountyPayment, __instance.Map, null);
 						bounty = 0;
 						ShipInteriorMod2.WorldComp.PlayerFactionBounty = bounty;
 					};
 					diaOption3.resolveTree = true;
 					diaNode.options.Add(diaOption3);
-					if (AmountSendableSilver(__instance.Map) < 2500 * bounty)
+					if (AmountSendableSilver(__instance.Map) < bountyPayment)
 					{
-						diaOption3.Disable(TranslatorFormattedStringExtensions.Translate("SoS.NotEnoughForBounty", 2500 * bounty));
+						diaOption3.Disable(TranslatorFormattedStringExtensions.Translate("SoS.NotEnoughForBounty", bountyPayment));
 					}
 				}
 			}

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Alert\AlertDodgeChanceBase.cs" />
     <Compile Include="Alert\AlertDodgeChanceEnemy.cs" />
     <Compile Include="Alert\AlertDodgeChancePlayer.cs" />
+    <Compile Include="Alert\AlertNotoriety.cs" />
     <Compile Include="Alert_ArchotechSporeMoodLow.cs" />
     <Compile Include="Alert_MechanitesInHomeArea.cs" />
     <Compile Include="ApparelHolographic.cs" />


### PR DESCRIPTION
Also make that alert display mean time between atacks to decrypt what "notoriety 45" or so actually means for player.
Notoriety nerf: bounty payment decreased 2x, Time between attacks increased 1.5x