### PR TITLE
Fix space map cache not purged on loading another save or starting

### DIFF
--- a/Source/1.6/Comp/ShipWorldComp.cs
+++ b/Source/1.6/Comp/ShipWorldComp.cs
@@ -27,12 +27,18 @@ namespace SaveOurShip2
 		public int LastStarshipBowTick = -StarhipBowTimeout;
 		public int LastFoundAmplifierTick = 0;
 
-		public ShipWorldComp(World world) : base(world)
+		// Purging persistent data related to old save after other game is loaded or new game is started
+		private void PurgePersistentData()
 		{
 			ShipInteriorMod2.PurgeWorldComp();
 			WorldUpdateRadiusHandler.PrurgeLayerRadiusSettings();
+			AccessExtensions.Utility.RecacheSpaceMaps();
+		}
 
-        }
+		public ShipWorldComp(World world) : base(world)
+		{
+			PurgePersistentData();
+		}
 
 		private int nextShipId = 0;
 		private int newShipId


### PR DESCRIPTION
non-space scenario, which might have caused recognizing surface map as space map with hypoxia and decompression effects applied.