### PR TITLE
A draft of fast leavings for all buildings. Reasonoing: calculating

### DIFF
--- a/Source/1.6/Comp/ShipMapComp.cs
+++ b/Source/1.6/Comp/ShipMapComp.cs
@@ -71,6 +71,14 @@ namespace SaveOurShip2
 			}
 		}
 
+		FastLeavingsCalculaor leavingsCalculaor;
+		public FastLeavingsCalculaor LeavingsCalculaor
+		{
+			get
+			{
+				return leavingsCalculaor;
+			}
+		}
 		public bool HasGravEngine
         {
 			get
@@ -371,10 +379,19 @@ namespace SaveOurShip2
 
 				Scribe_Collections.Look<Projectile>(ref incomingProjectiles, "incomingProjectiles", LookMode.Reference);
 			}
-			if (Scribe.mode == LoadSaveMode.LoadingVars)
+			if (Scribe.mode == LoadSaveMode.PostLoadInit)
 			{
 				// this cache has to be static - so clear it on load
 				bedsCache.Clear();
+				// See comments in FastLeavingsCalculaor
+				if (ShipMapState == ShipMapState.inCombat)
+				{
+					leavingsCalculaor = new FastLeavingsCalculaor(map);
+				}
+				else
+				{
+					leavingsCalculaor = null;
+				}
 			}
 		}
 		//SC only - both maps
@@ -1303,6 +1320,7 @@ namespace SaveOurShip2
 				RangeToKeep = Range;
 			}
 			InvaderLord = null;
+			leavingsCalculaor = new FastLeavingsCalculaor(map);
 		}
 		private void DetermineInitialRange(bool ambush)
 		{
@@ -2868,6 +2886,7 @@ namespace SaveOurShip2
 			OriginMapComp.ShipCombatTargetMap = null;
 			OriginMapComp.originMapComp = null;
 			OriginMapComp.targetMapComp = null;
+			leavingsCalculaor = null;
 		}
 		
 		//proj

--- a/Source/1.6/FastLeavingsCalculaor.cs
+++ b/Source/1.6/FastLeavingsCalculaor.cs
@@ -19,8 +19,6 @@ namespace SaveOurShip2
 		// Also players can remove mods mid-save, so recalculate after save-load will be more robust as well
 		Map map;
 		ShipMapComp mapComp;
-		//Map targetMap;
-		//ShipMapComp targetMapComp;
 		private ConcurrentDictionary<string, ThingOwner<Thing>> cachedLeavings = new ConcurrentDictionary<string, ThingOwner<Thing>>();
 		public FastLeavingsCalculaor(Map map)
 		{
@@ -31,8 +29,18 @@ namespace SaveOurShip2
 				Log.Error("SOS 2: Fast leavings used for non-combat map");
 				return;
 			}
-			//targetMap = originMapComp.ShipCombatTargetMap;
-			//targetMapComp = targetMap.GetComponent<ShipMapComp>();
+			LongEventHandler.QueueLongEvent(PreCalculateLeavingsAsync, "", doAsynchronously: true, null);
+		}
+
+		private void PreCalculateLeavingsAsync()
+		{
+			foreach (SpaceShipCache ship in mapComp.ShipsOnMap.Values)
+			{
+				foreach (Building b in ship.Buildings)
+				{
+					CalculateLeavingsFor(b);
+				}
+			}
 		}
 
 		public bool ShouldUseFastLeavings(Building destroyedBuilding)

--- a/Source/1.6/FastLeavingsCalculaor.cs
+++ b/Source/1.6/FastLeavingsCalculaor.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using RimWorld;
+using UnityEngine;
+using Vehicles;
+using Verse;
+using Debug = System.Diagnostics.Debug;
+
+
+namespace SaveOurShip2
+{
+	public class FastLeavingsCalculaor
+	{
+		// Calculator is per map.
+		// Haning it paer-ship-battle will avoid any persistence issues.
+		// Also players can remove mods mid-save, so recalculate after save-load will be more robust as well
+		Map map;
+		ShipMapComp mapComp;
+		//Map targetMap;
+		//ShipMapComp targetMapComp;
+		private ConcurrentDictionary<string, ThingOwner<Thing>> cachedLeavings = new ConcurrentDictionary<string, ThingOwner<Thing>>();
+		public FastLeavingsCalculaor(Map map)
+		{
+			this.map = map;
+			mapComp = this.map.GetComponent<ShipMapComp>();
+			if (mapComp.ShipMapState != ShipMapState.inCombat)
+			{
+				Log.Error("SOS 2: Fast leavings used for non-combat map");
+				return;
+			}
+			//targetMap = originMapComp.ShipCombatTargetMap;
+			//targetMapComp = targetMap.GetComponent<ShipMapComp>();
+		}
+
+		public bool ShouldUseFastLeavings(Building destroyedBuilding)
+		{
+			// TODO: there might be other concerns tro add.
+			// Comp refuelable: different refuelable objects will drop different amout of fuel.
+			CompRefuelable refuelable = destroyedBuilding.TryGetComp<CompRefuelable>();
+			if (refuelable != null)
+			{
+				return false;
+			}
+			if (destroyedBuilding is Frame)
+			{
+				return false;
+			}
+			return true;
+		}
+
+		public void DoLeavingsForDestroyedBuilding(Building destroyedBuilding, Map map, CellRect leavingsRect)
+		{
+			Debug.Assert(map == this.map);
+			// On cache miss, have to calculate leavings syncronously
+			if (!cachedLeavings.ContainsKey(destroyedBuilding.def.defName))
+			{
+				CalculateLeavingsFor(destroyedBuilding);
+			}
+			PlaceLeavings(destroyedBuilding.def.defName, cachedLeavings[destroyedBuilding.def.defName], map, leavingsRect);
+		}
+
+		private void CalculateLeavingsFor(Building destroyedBuilding)
+		{
+			
+			List<ThingDefCountClass> leavingItems = new List<ThingDefCountClass>();
+			if (Rand.Chance(destroyedBuilding.def.killedLeavingsChance))
+			{
+				if (destroyedBuilding.def.killedLeavings != null)
+				{
+					leavingItems.AddRange(destroyedBuilding.def.killedLeavings);
+				}
+				if (destroyedBuilding.HostileTo(Faction.OfPlayer) && destroyedBuilding.def.killedLeavingsPlayerHostile != null)
+				{
+					leavingItems.AddRange(destroyedBuilding.def.killedLeavingsPlayerHostile);
+				}
+				if (destroyedBuilding.def.killedLeavingsRanges != null)
+				{
+					foreach (ThingDefCountRangeClass range in destroyedBuilding.def.killedLeavingsRanges)
+					{
+						leavingItems.Add(new ThingDefCountClass(range.thingDef, Mathf.RoundToInt(Rand.RangeInclusive(range.countRange.min,
+																									                  range.countRange.max))));
+					}
+				}
+			}
+			ThingOwner<Thing> leavings = new ThingOwner<Thing>();
+			if (destroyedBuilding.def.leaveResourcesWhenKilled)
+			{
+				foreach(ThingDefCountClass leavingItem in leavingItems)
+				{
+					bool needSpawn = true;
+					if (leavingItem.IsChanceBased)
+					{
+						needSpawn = Rand.Chance(leavingItem.DropChance);
+					}
+					if (needSpawn && leavingItem.count > 0)
+					{
+						Thing item = ThingMaker.MakeThing(leavingItem.thingDef);
+						item.stackCount = leavingItem.count;
+						leavings.TryAdd(item);
+					}
+				}
+			}
+			cachedLeavings.TryAdd(destroyedBuilding.def.defName, leavings);
+		}
+
+		private void PlaceLeavings(string buildingDefName, ThingOwner<Thing> leavings, Map map, CellRect leavingsRect)
+		{
+			ThingOwner<Thing> leavingsCopy = new ThingOwner<Thing>();
+			foreach(Thing thing in leavings)
+			{
+				Thing newThing = ThingMaker.MakeThing(thing.def);
+				newThing.stackCount = thing.stackCount;
+				leavingsCopy.TryAdd(newThing);
+			}
+			int dropCellIndex = 0;
+			while (leavingsCopy.Count > 0)
+			{
+				Thing item = leavingsCopy[0];
+				item.SetForbidden(true, warnOnFail: false);
+				bool dropSuccessful = leavingsCopy.TryDrop(item, leavingsRect.ToList()[dropCellIndex], map, ThingPlaceMode.Near, out Thing resultThing, null);
+				dropCellIndex++;
+				if (dropCellIndex >= leavingsRect.Area)
+				{
+					dropCellIndex = 0;
+				}
+				if (!dropSuccessful)
+				{
+					Log.Warning("SOS 2: failed to place leavings fast, building: " + buildingDefName + "in rect: " + leavingsRect);
+				}
+			}
+		}
+
+	}
+}
+

--- a/Source/1.6/HarmonyPatchesPerformance.cs
+++ b/Source/1.6/HarmonyPatchesPerformance.cs
@@ -127,6 +127,16 @@ namespace SaveOurShip2
                 }
                 return false;
             }
+
+            if (diedThing is Building b)
+            {
+                ShipMapComp mapComp = map.GetComponent<ShipMapComp>();
+                if (mapComp.LeavingsCalculaor?.ShouldUseFastLeavings(b) ?? false)
+                {
+                    mapComp.LeavingsCalculaor.DoLeavingsForDestroyedBuilding(b, map, leavingsRect);
+                    return false;
+				}
+            }
             return true;
         }
     }

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Def\DodgeChanceSubmodScaleDef.cs" />
     <Compile Include="Def\GlobalUnlockDef.cs" />
     <Compile Include="Designator_RestoreHull.cs" />
+    <Compile Include="FastLeavingsCalculaor.cs" />
     <Compile Include="GenAdjExtension.cs" />
     <Compile Include="HarmonyCustomPatches.cs" />
     <Compile Include="HarmonyPatchesPerformance.cs" />


### PR DESCRIPTION
and spawning leavings during ship battle was profiled to be slow. However, fast leavings for ship hull partiall fixed that.

Todo:
1. Test performance. There is no stable test yet.
2. Add comp leavings, they currently won't be dropped.
3. Add parallel dictionary filling.