### PR TITLE
Tactical Console

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -1444,9 +1444,6 @@
 		<building>
 			<isSittable>true</isSittable>
 		</building>
-		<placeWorkers>
-			<li>SaveOurShip2.PlaceWorker_OnShipHull</li>
-		</placeWorkers>
 		<researchPrerequisites>
 			<li>ShipPilotSeat</li>
 		</researchPrerequisites>


### PR DESCRIPTION
Removed hull requirement to make it easier to use security structures on the ground.