### PR TITLE
Missile girl compatibility: as they throttle alert and confortable

### DIFF
--- a/Source/1.6/HarmonyPatchesPerformance.cs
+++ b/Source/1.6/HarmonyPatchesPerformance.cs
@@ -23,6 +23,12 @@ namespace SaveOurShip2
         private const int inactiveUpdateFactor = 16;
         public static bool Prefix(Alert __instance)
         {
+            if (ModIntegration.IsMissileGirlActive())
+            {
+                // Do not throttle alerts, as that is done in Missile Girl too and double throttled alerts are an issue
+                // as theit timings become like several dozens of seconds to apapper, waay too noticable.
+                return true;
+            }
             if (!counters.ContainsKey(__instance))
             {
                 counters.Add(__instance, 0);
@@ -66,8 +72,15 @@ namespace SaveOurShip2
 
         public static bool Prefix(Pawn p, ref FloatRange __result, out bool __state)
         {
-            // Occasionally completely clear cache to remove no longer existing enemy pawns, pawns from closed maps, etc
-            if (Find.TickManager.TicksGame % GenDate.TicksPerDay == 0)
+			if (ModIntegration.IsMissileGirlActive())
+			{
+                // Do not optimize comofrable temperature getter, as it is again duplicates with Missile Girl and could cause 
+                // too long update delays with double throttling.
+                __state = false;
+				return true;
+			}
+			// Occasionally completely clear cache to remove no longer existing enemy pawns, pawns from closed maps, etc
+			if (Find.TickManager.TicksGame % GenDate.TicksPerDay == 0)
             {
                 cachedTemperatureRanges.Clear();
             }

--- a/Source/1.6/ModIntegration.cs
+++ b/Source/1.6/ModIntegration.cs
@@ -24,6 +24,12 @@ namespace SaveOurShip2
 			return ModLister.HasActiveModWithName(CEModName);
 		}
 
+		public const string MissileGirlModID = "vr.missilegirl";
+		public static bool IsMissileGirlActive()
+		{
+			return ModLister.GetActiveModWithIdentifier(MissileGirlModID, true) != null;
+		}
+
 		// Because of Odyssey changes, need to place world objects further from each other,
 		// as zoomin in in orbit normally results in hiding orbit, switching to syrface layer.
 		public const float NewOdyOffsetScale = 2.5f;


### PR DESCRIPTION
temperature updates too, disable SOS 2 own throttling if Missile Girl is active. That double throttling led to dozens of seconds to wait before alert appears.
Their alert throtting looks reasonble for important dodge chance alert: it appears and updates reasonable quickly.