### PR TITLE
Fixed weapon tech names, so that they no longer contain very inaccurate

### DIFF
--- a/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
+++ b/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
@@ -671,7 +671,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretAC</defName>
 		<label>ship cannons</label>
-		<description>Construct ballistic slugthrowers for ship-to-ship combat. Unlike energy weapons, these require ammo but need almost no cooling. Can intercept torpedoes and shuttles.</description>
+		<description>Construct ballistic slugthrowers for ship-to-ship combat. Unlike energy weapons, these require ammo but produce almost no heat. Can intercept torpedoes and shuttles.</description>
 		<baseCost>800</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
@@ -821,7 +821,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretMedium</defName>
 		<label>heavy armaments</label>
-		<description>Construct larger versions of ship turrets. Largre turrets are not capablble of point defense against incoming shuttles and torpedoes.</description>
+		<description>Construct larger versions of ship turrets. Large turrets are not capablble of point defense against incoming shuttles and torpedoes.</description>
 		<baseCost>4000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
@@ -851,7 +851,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretLarge</defName>
 		<label>spinal armaments</label>
-		<description>Construct modular spinal-mount weapons consisting of spinal barrel, optional amplifiers and spinal capacitor.</description>
+		<description>Construct modular spinal-mount weapons consisting of spinal barrel, optional amplifiers and a spinal capacitor.</description>
 		<baseCost>6000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>

--- a/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
+++ b/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
@@ -671,7 +671,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretAC</defName>
 		<label>ship cannons</label>
-		<description>Construct ballistic slugthrowers for ship-to-ship combat. Unlike energy weapons, these require ammo but need almost no cooling.</description>
+		<description>Construct ballistic slugthrowers for ship-to-ship combat. Unlike energy weapons, these require ammo but need almost no cooling. Can intercept torpedoes and shuttles.</description>
 		<baseCost>800</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
@@ -696,7 +696,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretLaser</defName>
 		<label>laser turrets</label>
-		<description>Construct small lasers for ship-to-ship combat. Highly damaging but only usable at short range. Can intercept torpedoes.</description>
+		<description>Construct small lasers for ship-to-ship combat. Highly damaging but only usable at short range. Can intercept torpedoes and shuttles.</description>
 		<baseCost>2000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
@@ -821,7 +821,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretMedium</defName>
 		<label>heavy armaments</label>
-		<description>Construct larger versions of ship turrets, suitable for a mid-sized cruiser.</description>
+		<description>Construct larger versions of ship turrets. Largre turrets are not capablble of point defense against incoming shuttles and torpedoes.</description>
 		<baseCost>4000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>
@@ -837,7 +837,7 @@
 		<researchViewY>4.25</researchViewY>
 		<generalRules>
 		  <rulesStrings>
-			<li>subject->cruiser armaments</li>
+			<li>subject->heavy armaments</li>
 
 			<li>subject_story->was taken captive during an arms race between rival planets, forced to design starship weaponry for the opposing side</li>
 			<li>subject_story->oversaw the retrofit of an interstellar passenger liner into a vessel of war</li>
@@ -851,7 +851,7 @@
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretLarge</defName>
 		<label>spinal armaments</label>
-		<description>Construct modular spinal-mount weapons, typically seen only on capital ships.</description>
+		<description>Construct modular spinal-mount weapons consisting of spinal barrel, optional amplifiers and spinal capacitor.</description>
 		<baseCost>6000</baseCost>
 		<techLevel>Spacer</techLevel>
 		<prerequisites>

--- a/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
+++ b/1.6/Defs/ResearchProjectDefs/ResearchProjects_Ship.xml
@@ -820,7 +820,7 @@
 	</ResearchProjectDef>
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretMedium</defName>
-		<label>cruiser armaments</label>
+		<label>heavy armaments</label>
 		<description>Construct larger versions of ship turrets, suitable for a mid-sized cruiser.</description>
 		<baseCost>4000</baseCost>
 		<techLevel>Spacer</techLevel>
@@ -850,7 +850,7 @@
 	</ResearchProjectDef>
 	<ResearchProjectDef ParentName="ShipResearchProjectBase">
 		<defName>ShipTurretLarge</defName>
-		<label>capital ship armaments</label>
+		<label>spinal armaments</label>
 		<description>Construct modular spinal-mount weapons, typically seen only on capital ships.</description>
 		<baseCost>6000</baseCost>
 		<techLevel>Spacer</techLevel>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -1023,7 +1023,7 @@
 		</costList>
 		<uiIconPath>Things/Building/Ship/TurretACIII_MenuIcon</uiIconPath>
 		<researchPrerequisites>
-			<li>ShipTurretLarge</li>
+			<li>ShipTurretMedium</li>
 		</researchPrerequisites>
 		<size>(5,5)</size>
 	</ThingDef>


### PR DESCRIPTION
references to specific ship classes. As latest tech became spinal weapons, non-spinal artillery turret was moved from that tech to lower one.