### PR TITLE
Added decouplers: automatically exploding on tick comp. Intended to

### DIFF
--- a/Source/1.6/Comp/CompExplosiveInstant.cs
+++ b/Source/1.6/Comp/CompExplosiveInstant.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using RimWorld;
+
+namespace SaveOurShip2
+{
+	class CompExplosiveInstant : CompExplosive
+	{
+		public override void CompTick()
+		{
+			if (parent.Spawned)
+			{
+				Detonate(parent.MapHeld);
+			}
+		}
+	}
+}

--- a/Source/1.6/CompProps/CompProps_ExplosiveInstant.cs
+++ b/Source/1.6/CompProps/CompProps_ExplosiveInstant.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using RimWorld;
+
+namespace SaveOurShip2
+{
+	class CompProperties_ExplosiveInstant : CompProperties_Explosive
+	{
+		public CompProperties_ExplosiveInstant()
+		{
+			compClass = typeof(CompExplosiveInstant);
+		}
+	}
+}

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -107,6 +107,8 @@
     <Compile Include="ApparelHolographic.cs" />
     <Compile Include="ArrivalAction\AerialVehicleArrivalAction_ShipAssault.cs" />
     <Compile Include="ArrivalAction\PawnPublicizer.cs" />
+    <Compile Include="CompProps\CompProps_ExplosiveInstant.cs" />
+    <Compile Include="Comp\CompExplosiveInstant.cs" />
     <Compile Include="Comp\CompHyperchargingBattery.cs" />
     <Compile Include="Comp\CompShipBay.cs" />
     <Compile Include="Def\ArchoGiftDef.cs" />


### PR DESCRIPTION
build fighter/ship wings that are connected and recognized as one ship, but disconnected on tick via explosion. Upgrading to disconnect on ship spawn is possible.