### PR TITLE
Temporarily remove go home command for shuttles,as it is a little more

### DIFF
--- a/Source/1.6/Vehicles/CompShuttleLauncher.cs
+++ b/Source/1.6/Vehicles/CompShuttleLauncher.cs
@@ -50,8 +50,7 @@ namespace SaveOurShip2.Vehicles
 					}
 					yield return board;
 				}
-                else
-                    yield return CommandGoHome(vehicle);
+				// TODO: fix and add CommandGoHome back here if map is non-player. Although this command duplicates normal launch.
 				//samey in ShuttleTakeoff.FloatMenuMissions
 				if (vehicle.CompUpgradeTree != null)
 				{
@@ -103,6 +102,7 @@ namespace SaveOurShip2.Vehicles
             };
         }
 
+        // TODO: This command now needs fixing as of 1.6 and Vehicle Framework 1.6.2144
         Command_Action CommandGoHome(VehiclePawn vehicle)
         {
             return new Command_Action


### PR DESCRIPTION
convenient duplicate to normal launch commands and currently not working.