### PR TITLE
SOS2 enines for gravship 

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -927,6 +927,7 @@
 		</statBases>
 		<tickerType>Normal</tickerType>
 		<description>A chemfuel-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 500\nFuel use: 1 chemfuel/s\nMax takeoff strength: 750</description>
+		<description MayRequire="Ludeon.RimWorld.Odyssey">A chemfuel-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 500\nFuel use: 1 chemfuel/s\nMax takeoff strength: 750\n\nGravship use specifics: a relatively small rocket, simple enough to bolt onto a gravship without fuss.\n\nGameplay effect: doubles as a thruster and a fuel tank. Adds +15 to max travel range. Must be entirely placed on a gravship substructure.</description>
 		<size>(2,3)</size>
 		<receivesSignals>true</receivesSignals>
 		<designationCategory>Ship</designationCategory>
@@ -968,6 +969,42 @@
 				<killZoneWidth>4</killZoneWidth>
 				<soundWorking>ShipEngineFuel</soundWorking>
 			</li>
+			<!-- Odyssey: doubles as a gravship thruster that holds its own fuel (range + FuelStorage in one) -->
+			<li Class="CompProperties_GravshipThruster" MayRequire="Ludeon.RimWorld.Odyssey">
+				<componentTypeDef>Thruster</componentTypeDef>
+				<providesFuel>true</providesFuel>
+				<statOffsets>
+					<GravshipRange>15</GravshipRange>
+				</statOffsets>
+				<requiresLOS>false</requiresLOS>
+				<maxSimultaneous>4</maxSimultaneous>
+				<maxDistance>500</maxDistance>
+				<directionInfluence>20</directionInfluence>
+				<flameSize>5.0</flameSize>
+				<flameOffsetsPerDirection>
+					<li>(0, 0, 0.85)</li>
+					<li>(0, 0, 0.85)</li>
+					<li>(0, 0, 0.85)</li>
+					<li>(0, 0, 0.85)</li>
+				</flameOffsetsPerDirection>
+				<flameShaderType>MoteGlow</flameShaderType>
+				<flameShaderParameters>
+					<_MainTex>/Things/Mote/LargeThruster_Burn</_MainTex>
+				</flameShaderParameters>
+				<exhaustSettings>
+					<exhaustFleckDef>GravshipThrusterExhaust</exhaustFleckDef>
+					<emissionsPerSecond>40.0</emissionsPerSecond>
+					<spawnRadiusRange>0.0~0.5</spawnRadiusRange>
+					<velocity>(0.0,0.0,-20.0)</velocity>
+					<velocityRotationRange>-10.0~10.0</velocityRotationRange>
+					<velocityMultiplierRange>0.8~1.2</velocityMultiplierRange>
+					<rotationOverTimeRange>-180.0~180.0</rotationOverTimeRange>
+					<scaleRange>1.5~3.0</scaleRange>
+				</exhaustSettings>
+			</li>
+			<li Class="CompProperties_Breakdownable" MayRequire="Ludeon.RimWorld.Odyssey">
+				<compClass>SaveOurShip2.CompShipEngineBreakdownable</compClass>
+			</li>
 			<li Class="Rimefeller.CompProperties_Pipe" MayRequire="Dubwise.Rimefeller"/>
 		</comps>
 		<placeWorkers>
@@ -1005,6 +1042,7 @@
 		</statBases>
 		<tickerType>Normal</tickerType>
 		<description>A chemfuel-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 1000\nFuel use: 2 chemfuel/s\nMax takeoff strength: 1000</description>
+		<description MayRequire="Ludeon.RimWorld.Odyssey">A chemfuel-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 1000\nFuel use: 2 chemfuel/s\nMax takeoff strength: 1000\n\nGravship use specifics: a reliable and efficient rocket engine.\n\nGameplay effect: doubles as a thruster and a fuel tank. Adds +30 to max travel range. Must be entirely placed on a gravship substructure.</description>
 		<size>(3,3)</size>
 		<receivesSignals>true</receivesSignals>
 		<designationCategory>Ship</designationCategory>
@@ -1046,6 +1084,44 @@
 				<killZoneWidth>5</killZoneWidth>
 				<soundWorking>ShipEngineFuel</soundWorking>
 			</li>
+			<!-- Odyssey: doubles as a gravship thruster that holds its own fuel (range + FuelStorage in one) -->
+			<li Class="CompProperties_GravshipThruster" MayRequire="Ludeon.RimWorld.Odyssey">
+				<componentTypeDef>Thruster</componentTypeDef>
+				<providesFuel>true</providesFuel>
+				<maxSimultaneous>2</maxSimultaneous>
+				<fuelSavingsPercent>0.10</fuelSavingsPercent>
+				<statOffsets>
+					<GravshipRange>30</GravshipRange>
+				</statOffsets>
+				<requiresLOS>false</requiresLOS>
+				<maxSimultaneous>2</maxSimultaneous>
+				<maxDistance>500</maxDistance>
+				<directionInfluence>30</directionInfluence>
+				<flameSize>6.0</flameSize>
+				<flameOffsetsPerDirection>
+					<li>(0, 0, 1.5)</li>
+					<li>(0, 0, 1.5)</li>
+					<li>(0, 0, 1.5)</li>
+					<li>(0, 0, 1.5)</li>
+				</flameOffsetsPerDirection>
+				<flameShaderType>MoteGlow</flameShaderType>
+				<flameShaderParameters>
+					<_MainTex>/Things/Mote/LargeThruster_Burn</_MainTex>
+				</flameShaderParameters>
+				<exhaustSettings>
+					<exhaustFleckDef>GravshipThrusterExhaust</exhaustFleckDef>
+					<emissionsPerSecond>50.0</emissionsPerSecond>
+					<spawnRadiusRange>0.0~0.7</spawnRadiusRange>
+					<velocity>(0.0,0.0,-22.0)</velocity>
+					<velocityRotationRange>-10.0~10.0</velocityRotationRange>
+					<velocityMultiplierRange>0.8~1.2</velocityMultiplierRange>
+					<rotationOverTimeRange>-180.0~180.0</rotationOverTimeRange>
+					<scaleRange>1.8~3.4</scaleRange>
+				</exhaustSettings>
+			</li>
+			<li Class="CompProperties_Breakdownable" MayRequire="Ludeon.RimWorld.Odyssey">
+				<compClass>SaveOurShip2.CompShipEngineBreakdownable</compClass>
+			</li>
 			<li Class="Rimefeller.CompProperties_Pipe" MayRequire="Dubwise.Rimefeller"/>
 		</comps>
 		<placeWorkers>
@@ -1085,6 +1161,7 @@
 		</statBases>
 		<tickerType>Normal</tickerType>
 		<description>A nuclear-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 3000\nFuel use: 3 fuel pods/s\nMax takeoff strength: 4000</description>
+		<description MayRequire="Ludeon.RimWorld.Odyssey">A nuclear-powered engine capable of launching a ship into orbit. Not suitable for interplanetary travel.\n\nThrust: 3000\nFuel use: 3 fuel pods/s\nMax takeoff strength: 4000\n\nGravship use specifics: this monstrous engine was designed to propel a colossal mass of dreadnoughts and interplanetary freighters. When jury-rigged to a weightless gravship it can easily fly you anywhere on a planet in no time and with exceptional fuel efficiency... Too easily.\n\nGameplay effect: only one is required to maximize range, and fuel consumption is greatly reduced. However, its sheer power makes gravship controls fiddly, reducing piloting quality. Adds +500 to max travel range, but -15 to piloting quality. Must be entirely placed on a gravship substructure.</description>
 		<size>(5,5)</size>
 		<receivesSignals>true</receivesSignals>
 		<designationCategory>Ship</designationCategory>
@@ -1125,6 +1202,43 @@
 				<killZoneLength>15</killZoneLength>
 				<killZoneWidth>9</killZoneWidth>
 				<soundWorking>ShipEngineFuel</soundWorking>
+			</li>
+			<!-- Odyssey: doubles as a gravship thruster that holds its own fuel (range + FuelStorage in one) -->
+			<li Class="CompProperties_GravshipThruster" MayRequire="Ludeon.RimWorld.Odyssey">
+				<componentTypeDef>Thruster</componentTypeDef>
+				<providesFuel>true</providesFuel>
+				<fuelSavingsPercent>0.4</fuelSavingsPercent>
+				<statOffsets>
+					<GravshipRange>500</GravshipRange>
+				</statOffsets>
+				<requiresLOS>false</requiresLOS>
+				<maxSimultaneous>1</maxSimultaneous>
+				<maxDistance>500</maxDistance>
+				<directionInfluence>50</directionInfluence>
+				<flameSize>9.0</flameSize>
+				<flameOffsetsPerDirection>
+					<li>(0, 0, 3.95)</li>
+					<li>(0, 0, 3.95)</li>
+					<li>(0, 0, 3.95)</li>
+					<li>(0, 0, 3.95)</li>
+				</flameOffsetsPerDirection>
+				<flameShaderType>MoteGlow</flameShaderType>
+				<flameShaderParameters>
+					<_MainTex>/Things/Mote/LargeThruster_Burn</_MainTex>
+				</flameShaderParameters>
+				<exhaustSettings>
+					<exhaustFleckDef>GravshipThrusterExhaust</exhaustFleckDef>
+					<emissionsPerSecond>70.0</emissionsPerSecond>
+					<spawnRadiusRange>0.0~1.0</spawnRadiusRange>
+					<velocity>(0.0,0.0,-26.0)</velocity>
+					<velocityRotationRange>-10.0~10.0</velocityRotationRange>
+					<velocityMultiplierRange>0.8~1.2</velocityMultiplierRange>
+					<rotationOverTimeRange>-180.0~180.0</rotationOverTimeRange>
+					<scaleRange>2.2~4.2</scaleRange>
+				</exhaustSettings>
+			</li>
+			<li Class="CompProperties_Breakdownable" MayRequire="Ludeon.RimWorld.Odyssey">
+				<compClass>SaveOurShip2.CompShipEngineBreakdownable</compClass>
 			</li>
 		</comps>
 		<placeWorkers>

--- a/1.6/ExpansionPatches/Odyssey/Patches/gravship_engines.xml
+++ b/1.6/ExpansionPatches/Odyssey/Patches/gravship_engines.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- Register SOS2 engines as linkable facilities on the grav engine. CompAffectedByFacilities uses
+	     a whitelist; without this the engines never link, so their CompGravshipFacility (thruster range,
+	     fuel, componentTypeDef) is never applied. This is what makes them count as gravship thrusters. -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="GravEngine"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+		<value>
+			<li>Ship_Engine_Small</li>
+			<li>Ship_Engine</li>
+			<li>Ship_Engine_Large</li>
+		</value>
+	</Operation>
+
+	<!-- SOS2 nuclear engine: its raw power makes gravship controls fiddly - launch-quality penalty.
+	     Vanilla quality offsets for reference: SmallThruster +0.01, LargeThruster +0.03, PilotSubpersonaCore +0.15. -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RitualOutcomeEffectDef[defName="GravshipLaunch"]/comps</xpath>
+		<value>
+			<li Class="RitualOutcomeComp_GravshipFacilities">
+				<label>oversized engines</label>
+				<facilityQualityOffsets>
+					<li>
+						<key>Ship_Engine_Large</key>
+						<value>-0.15</value>
+					</li>
+				</facilityQualityOffsets>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -41,4 +41,44 @@ namespace SaveOurShip2
 				__result = "";
 		}
 	}
+
+	// Boundary safety: a SOS2 engine that's part of a SOS2 ship structure must not also pose as a
+	// gravship thruster - the SOS2 ship would tear it off on move, the gravship would tear it off on
+	// launch, and both systems would double-claim its fuel. Refuse to link/be-active in that case;
+	// the dual role activates only when the engine is standalone (no SOS2 ship cache on its cell).
+	[HarmonyPatch(typeof(CompGravshipThruster), nameof(CompGravshipThruster.CanLink))]
+	public static class CompGravshipThruster_CanLink_NotOnShip
+	{
+		public static void Postfix(CompGravshipThruster __instance, ref bool __result)
+		{
+			if (__result && IsOnSos2Ship(__instance.parent))
+				__result = false;
+		}
+
+		public static bool IsOnSos2Ship(Thing engine)
+		{
+			if (engine == null || !engine.Spawned)
+				return false;
+			//SOS2 engine has CompShipCachePart by def - the meaningful question is whether its cell
+			//is currently registered to a ship in the map's ShipMapComp
+			if (engine.TryGetComp<CompShipCachePart>() == null)
+				return false;
+			ShipMapComp mapComp = engine.Map?.GetComponent<ShipMapComp>();
+			if (mapComp == null)
+				return false;
+			return mapComp.ShipIndexOnVec(engine.Position) != -1;
+		}
+	}
+
+	// Symmetric guard on CanBeActive: even if a stale link slipped past CanLink (e.g. the engine
+	// joined a SOS2 ship cache after linking), don't let the thruster contribute during launch.
+	[HarmonyPatch(typeof(CompGravshipThruster), nameof(CompGravshipThruster.CanBeActive), MethodType.Getter)]
+	public static class CompGravshipThruster_CanBeActive_NotOnShip
+	{
+		public static void Postfix(CompGravshipThruster __instance, ref bool __result)
+		{
+			if (__result && CompGravshipThruster_CanLink_NotOnShip.IsOnSos2Ship(__instance.parent))
+				__result = false;
+		}
+	}
 }

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -60,9 +60,42 @@ namespace SaveOurShip2
 				if (mapComp.MapShipCells.ContainsKey(cell))
 					mapComp.MapShipCells.Remove(cell);
 			}
-			//if the ship is now empty drop it from ShipsOnMap (otherwise it lingers as a zombie cache)
-			if (ship != null && ship.BuildingCount <= 0 && idx != -1)
-				mapComp.RemoveShipFromCache(idx);
+			//catch any empty ships - the one this part was just removed from, and any others (e.g.
+			//pre-existing zombies left by the prior prefix-skip implementation, or odd loads).
+			//Use Buildings.Count as the source of truth (BuildingCount field can drift).
+			PruneEmptyShips(mapComp);
+		}
+
+		public static void PruneEmptyShips(ShipMapComp mapComp)
+		{
+			if (mapComp == null) return;
+			List<int> empties = null;
+			foreach (var kv in mapComp.ShipsOnMap)
+			{
+				SpaceShipCache s = kv.Value;
+				if (s == null || s.Buildings == null || s.Buildings.Count == 0)
+				{
+					if (empties == null) empties = new List<int>();
+					empties.Add(kv.Key);
+				}
+			}
+			if (empties != null)
+			{
+				foreach (int idx in empties)
+					mapComp.RemoveShipFromCache(idx);
+			}
+		}
+	}
+
+	// Sweep empty SpaceShipCache entries on map FinalizeInit - catches zombie ships persisted from
+	// pre-fix saves (engine-on-substructure left an empty cache) or any other source of 0-part ships.
+	[HarmonyPatch(typeof(Map), nameof(Map.FinalizeInit))]
+	public static class Map_FinalizeInit_PruneEmptyShipCaches
+	{
+		public static void Postfix(Map __instance)
+		{
+			ShipMapComp mapComp = __instance.GetComponent<ShipMapComp>();
+			GravshipDetach.PruneEmptyShips(mapComp);
 		}
 	}
 

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -87,6 +87,22 @@ namespace SaveOurShip2
 		}
 	}
 
+	// CompGravshipThruster hard-requires a CompBreakdownable - its CanBeActive (and inspect string)
+	// dereference Breakdownable and NRE without one. SOS2 engines should never actually break down,
+	// so this variant satisfies that requirement but immediately drops out of the BreakdownManager's
+	// roster, and DoBreakdown is patched out for it (see below).
+	public class CompShipEngineBreakdownable : CompBreakdownable
+	{
+		public override void PostSpawnSetup(bool respawningAfterLoad)
+		{
+			base.PostSpawnSetup(respawningAfterLoad); //base registers with the BreakdownManager
+			parent.Map?.GetComponent<BreakdownManager>()?.Deregister(this); //...drop straight back out
+		}
+	}
+
+
+	// ===== Harmony patches =====
+
 	// Sweep empty SpaceShipCache entries on map FinalizeInit - catches zombie ships persisted from
 	// pre-fix saves (engine-on-substructure left an empty cache) or any other source of 0-part ships.
 	[HarmonyPatch(typeof(Map), nameof(Map.FinalizeInit))]
@@ -131,20 +147,6 @@ namespace SaveOurShip2
 				if (t is Building b && b.TryGetComp<CompShipCachePart>() != null)
 					GravshipDetach.DetachFromSos2(b);
 			}
-		}
-	}
-
-
-	// CompGravshipThruster hard-requires a CompBreakdownable - its CanBeActive (and inspect string)
-	// dereference Breakdownable and NRE without one. SOS2 engines should never actually break down,
-	// so this variant satisfies that requirement but immediately drops out of the BreakdownManager's
-	// roster, and DoBreakdown is patched out for it (see below).
-	public class CompShipEngineBreakdownable : CompBreakdownable
-	{
-		public override void PostSpawnSetup(bool respawningAfterLoad)
-		{
-			base.PostSpawnSetup(respawningAfterLoad); //base registers with the BreakdownManager
-			parent.Map?.GetComponent<BreakdownManager>()?.Deregister(this); //...drop straight back out
 		}
 	}
 

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -1,0 +1,44 @@
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace SaveOurShip2
+{
+	// CompGravshipThruster hard-requires a CompBreakdownable - its CanBeActive (and inspect string)
+	// dereference Breakdownable and NRE without one. SOS2 engines should never actually break down,
+	// so this variant satisfies that requirement but immediately drops out of the BreakdownManager's
+	// roster, and DoBreakdown is patched out for it (see below).
+	public class CompShipEngineBreakdownable : CompBreakdownable
+	{
+		public override void PostSpawnSetup(bool respawningAfterLoad)
+		{
+			base.PostSpawnSetup(respawningAfterLoad); //base registers with the BreakdownManager
+			parent.Map?.GetComponent<BreakdownManager>()?.Deregister(this); //...drop straight back out
+		}
+	}
+
+	// DoBreakdown is the single chokepoint for every breakdown - the BreakdownManager's random check
+	// AND direct calls such as a failed gravship landing outcome. Deregistering only stops the former;
+	// skipping DoBreakdown here makes SOS2 engines immune to all of them.
+	[HarmonyPatch(typeof(CompBreakdownable), nameof(CompBreakdownable.DoBreakdown))]
+	public static class CompBreakdownable_DoBreakdown_ShipEngine
+	{
+		public static bool Prefix(CompBreakdownable __instance)
+		{
+			return !(__instance is CompShipEngineBreakdownable);
+		}
+	}
+
+	// A SOS2 engine carries CompGravshipThruster only as a secondary (Odyssey) role. While it isn't
+	// linked to a grav engine, the comp's red "not functional: not connected" inspect text is just
+	// noise on a working SOS2 engine - blank the thruster inspect line in that case.
+	[HarmonyPatch(typeof(CompGravshipThruster), nameof(CompGravshipThruster.CompInspectStringExtra))]
+	public static class CompGravshipThruster_InspectString_ShipEngine
+	{
+		public static void Postfix(CompGravshipThruster __instance, ref string __result)
+		{
+			if (__instance.parent.TryGetComp<CompEngineTrail>() != null && __instance.LinkedBuildings.NullOrEmpty())
+				__result = "";
+		}
+	}
+}

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -1,21 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
 using HarmonyLib;
 using RimWorld;
 using Verse;
 
 namespace SaveOurShip2
 {
-	// Helper: SOS2 engine sits on Odyssey gravship substructure (any cell under the engine has a
-	// substructure foundation). Used to gate the SOS2 ship-cache so a lone engine bolted to a
-	// gravship isn't pulled into SOS2's caching system and treated as a wreck.
-	static class ShipEngineSubstructureCheck
+	// Helper: building sits on Odyssey gravship substructure (any cell under it has a substructure
+	// foundation). Anything on gravship substructure cannot also be a SOS2 ship part - a lone engine,
+	// wall, or anything else bolted to a gravship must not be pulled into SOS2's caching system, or it
+	// gets treated as a wreck and the gravship gets misclassified.
+	static class GravshipSubstructureCheck
 	{
-		public static bool EngineOnGravship(Thing thing)
+		public static bool OnSubstructure(Thing thing)
 		{
 			if (!ModsConfig.OdysseyActive)
 				return false;
 			if (thing == null || !thing.Spawned)
 				return false;
-			if (thing.TryGetComp<CompEngineTrail>() == null)
+			if (thing.TryGetComp<CompShipCachePart>() == null)
 				return false;
 			Map map = thing.Map;
 			if (map == null)
@@ -32,27 +35,62 @@ namespace SaveOurShip2
 		}
 	}
 
-	// A SOS2 engine on gravship substructure must not be treated as a SOS2 ship part: skip the
-	// CompShipCachePart spawn logic that would register it in MapShipCells / spin up a new
-	// SpaceShipCache for it (would otherwise produce a one-engine wreck on the gravship). The
-	// engine still works (CompEngineTrail and its other comps are unaffected).
+	// A SOS2 ship part on gravship substructure must not be registered in SOS2's MapShipCells / spin
+	// up a SpaceShipCache. Skip the CompShipCachePart spawn logic entirely - the part still ticks
+	// normally (its other comps are unaffected), it just doesn't pretend to be part of a SOS2 ship.
 	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PostSpawnSetup))]
-	public static class CompShipCachePart_PostSpawnSetup_GravshipEngine
+	public static class CompShipCachePart_PostSpawnSetup_OnSubstructure
 	{
 		public static bool Prefix(CompShipCachePart __instance)
 		{
-			return !ShipEngineSubstructureCheck.EngineOnGravship(__instance.parent);
+			return !GravshipSubstructureCheck.OnSubstructure(__instance.parent);
 		}
 	}
 
-	// Symmetric guard on despawn - we never registered, so don't try to deregister either (the
-	// SOS2 despawn path NREs in some places when given a part it never tracked).
+	// Symmetric guard on despawn - if we skipped registration, skip deregistration too.
 	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PreDeSpawn))]
-	public static class CompShipCachePart_PreDeSpawn_GravshipEngine
+	public static class CompShipCachePart_PreDeSpawn_OnSubstructure
 	{
 		public static bool Prefix(CompShipCachePart __instance)
 		{
-			return !ShipEngineSubstructureCheck.EngineOnGravship(__instance.parent);
+			return !GravshipSubstructureCheck.OnSubstructure(__instance.parent);
+		}
+	}
+
+	// Retroactive case: SOS2 ship part already spawned + registered, then substructure laid under it.
+	// PostSpawnSetup ran before substructure existed, so the part stayed in the SOS2 cache. When
+	// substructure is set, scan the cell for any SOS2 ship parts and force-detach them: remove from
+	// the SpaceShipCache and clear their cells from MapShipCells. The next gravship launch then sees
+	// the part as a gravship facility, not a SOS2 wreck.
+	[HarmonyPatch(typeof(TerrainGrid), nameof(TerrainGrid.SetFoundation))]
+	public static class TerrainGrid_SetFoundation_DetachOnSubstructure
+	{
+		public static void Postfix(TerrainGrid __instance, IntVec3 c, TerrainDef newTerr)
+		{
+			if (newTerr == null || !newTerr.IsSubstructure)
+				return;
+			Map map = __instance.map; //publicized via Krafs.Publicizer
+			if (map == null || !c.InBounds(map))
+				return;
+			ShipMapComp mapComp = map.GetComponent<ShipMapComp>();
+			if (mapComp == null)
+				return;
+			//snapshot - RemoveFromCache mutates collections we might be iterating
+			List<Thing> things = c.GetThingList(map).ToList();
+			foreach (Thing t in things)
+			{
+				if (!(t is Building b) || b.TryGetComp<CompShipCachePart>() == null)
+					continue;
+				int idx = mapComp.ShipIndexOnVec(b.Position);
+				if (idx != -1 && mapComp.ShipsOnMap.ContainsKey(idx))
+					mapComp.ShipsOnMap[idx].RemoveFromCache(b, DestroyMode.Vanish);
+				//clear every cell this building occupies from MapShipCells - it is no longer a SOS2 ship part
+				foreach (IntVec3 cell in b.OccupiedRect())
+				{
+					if (mapComp.MapShipCells.ContainsKey(cell))
+						mapComp.MapShipCells.Remove(cell);
+				}
+			}
 		}
 	}
 

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -4,6 +4,59 @@ using Verse;
 
 namespace SaveOurShip2
 {
+	// Helper: SOS2 engine sits on Odyssey gravship substructure (any cell under the engine has a
+	// substructure foundation). Used to gate the SOS2 ship-cache so a lone engine bolted to a
+	// gravship isn't pulled into SOS2's caching system and treated as a wreck.
+	static class ShipEngineSubstructureCheck
+	{
+		public static bool EngineOnGravship(Thing thing)
+		{
+			if (!ModsConfig.OdysseyActive)
+				return false;
+			if (thing == null || !thing.Spawned)
+				return false;
+			if (thing.TryGetComp<CompEngineTrail>() == null)
+				return false;
+			Map map = thing.Map;
+			if (map == null)
+				return false;
+			foreach (IntVec3 c in thing.OccupiedRect())
+			{
+				if (!c.InBounds(map))
+					continue;
+				TerrainDef foundation = map.terrainGrid.FoundationAt(c);
+				if (foundation != null && foundation.IsSubstructure)
+					return true;
+			}
+			return false;
+		}
+	}
+
+	// A SOS2 engine on gravship substructure must not be treated as a SOS2 ship part: skip the
+	// CompShipCachePart spawn logic that would register it in MapShipCells / spin up a new
+	// SpaceShipCache for it (would otherwise produce a one-engine wreck on the gravship). The
+	// engine still works (CompEngineTrail and its other comps are unaffected).
+	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PostSpawnSetup))]
+	public static class CompShipCachePart_PostSpawnSetup_GravshipEngine
+	{
+		public static bool Prefix(CompShipCachePart __instance)
+		{
+			return !ShipEngineSubstructureCheck.EngineOnGravship(__instance.parent);
+		}
+	}
+
+	// Symmetric guard on despawn - we never registered, so don't try to deregister either (the
+	// SOS2 despawn path NREs in some places when given a part it never tracked).
+	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PreDeSpawn))]
+	public static class CompShipCachePart_PreDeSpawn_GravshipEngine
+	{
+		public static bool Prefix(CompShipCachePart __instance)
+		{
+			return !ShipEngineSubstructureCheck.EngineOnGravship(__instance.parent);
+		}
+	}
+
+
 	// CompGravshipThruster hard-requires a CompBreakdownable - its CanBeActive (and inspect string)
 	// dereference Breakdownable and NRE without one. SOS2 engines should never actually break down,
 	// so this variant satisfies that requirement but immediately drops out of the BreakdownManager's

--- a/Source/1.6/CompShipEngineBreakdownable.cs
+++ b/Source/1.6/CompShipEngineBreakdownable.cs
@@ -35,33 +35,53 @@ namespace SaveOurShip2
 		}
 	}
 
-	// A SOS2 ship part on gravship substructure must not be registered in SOS2's MapShipCells / spin
-	// up a SpaceShipCache. Skip the CompShipCachePart spawn logic entirely - the part still ticks
-	// normally (its other comps are unaffected), it just doesn't pretend to be part of a SOS2 ship.
-	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PostSpawnSetup))]
-	public static class CompShipCachePart_PostSpawnSetup_OnSubstructure
+	// Shared detach: pull a SOS2 ship part out of its SpaceShipCache and scrub every cell it occupies
+	// from MapShipCells. If the cache is left empty, drop it entirely. Used at two trigger points:
+	// part spawned on substructure, and substructure laid under an already-registered part.
+	static class GravshipDetach
 	{
-		public static bool Prefix(CompShipCachePart __instance)
+		public static void DetachFromSos2(Building b)
 		{
-			return !GravshipSubstructureCheck.OnSubstructure(__instance.parent);
+			if (b == null || !b.Spawned)
+				return;
+			Map map = b.Map;
+			if (map == null)
+				return;
+			ShipMapComp mapComp = map.GetComponent<ShipMapComp>();
+			if (mapComp == null)
+				return;
+			int idx = mapComp.ShipIndexOnVec(b.Position);
+			SpaceShipCache ship = null;
+			if (idx != -1 && mapComp.ShipsOnMap.TryGetValue(idx, out ship))
+				ship.RemoveFromCache(b, DestroyMode.Vanish);
+			//clear every cell this building occupies from MapShipCells - it is no longer a SOS2 ship part
+			foreach (IntVec3 cell in b.OccupiedRect())
+			{
+				if (mapComp.MapShipCells.ContainsKey(cell))
+					mapComp.MapShipCells.Remove(cell);
+			}
+			//if the ship is now empty drop it from ShipsOnMap (otherwise it lingers as a zombie cache)
+			if (ship != null && ship.BuildingCount <= 0 && idx != -1)
+				mapComp.RemoveShipFromCache(idx);
 		}
 	}
 
-	// Symmetric guard on despawn - if we skipped registration, skip deregistration too.
-	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PreDeSpawn))]
-	public static class CompShipCachePart_PreDeSpawn_OnSubstructure
+	// A SOS2 ship part on gravship substructure must not be a SOS2 ship part. Let vanilla PostSpawnSetup
+	// run normally (so all internal fields - map/mapComp/cellsUnder/fac - are initialized; otherwise
+	// CompInspectStringExtra and PostDeSpawn NRE), then immediately detach the part if on substructure.
+	[HarmonyPatch(typeof(CompShipCachePart), nameof(CompShipCachePart.PostSpawnSetup))]
+	public static class CompShipCachePart_PostSpawnSetup_OnSubstructure
 	{
-		public static bool Prefix(CompShipCachePart __instance)
+		public static void Postfix(CompShipCachePart __instance)
 		{
-			return !GravshipSubstructureCheck.OnSubstructure(__instance.parent);
+			if (GravshipSubstructureCheck.OnSubstructure(__instance.parent))
+				GravshipDetach.DetachFromSos2(__instance.parent as Building);
 		}
 	}
 
 	// Retroactive case: SOS2 ship part already spawned + registered, then substructure laid under it.
 	// PostSpawnSetup ran before substructure existed, so the part stayed in the SOS2 cache. When
-	// substructure is set, scan the cell for any SOS2 ship parts and force-detach them: remove from
-	// the SpaceShipCache and clear their cells from MapShipCells. The next gravship launch then sees
-	// the part as a gravship facility, not a SOS2 wreck.
+	// substructure is set, scan the cell for any SOS2 ship parts and force-detach them.
 	[HarmonyPatch(typeof(TerrainGrid), nameof(TerrainGrid.SetFoundation))]
 	public static class TerrainGrid_SetFoundation_DetachOnSubstructure
 	{
@@ -72,24 +92,11 @@ namespace SaveOurShip2
 			Map map = __instance.map; //publicized via Krafs.Publicizer
 			if (map == null || !c.InBounds(map))
 				return;
-			ShipMapComp mapComp = map.GetComponent<ShipMapComp>();
-			if (mapComp == null)
-				return;
-			//snapshot - RemoveFromCache mutates collections we might be iterating
-			List<Thing> things = c.GetThingList(map).ToList();
-			foreach (Thing t in things)
+			//snapshot - DetachFromSos2 mutates the cell's MapShipCells while we iterate
+			foreach (Thing t in c.GetThingList(map).ToList())
 			{
-				if (!(t is Building b) || b.TryGetComp<CompShipCachePart>() == null)
-					continue;
-				int idx = mapComp.ShipIndexOnVec(b.Position);
-				if (idx != -1 && mapComp.ShipsOnMap.ContainsKey(idx))
-					mapComp.ShipsOnMap[idx].RemoveFromCache(b, DestroyMode.Vanish);
-				//clear every cell this building occupies from MapShipCells - it is no longer a SOS2 ship part
-				foreach (IntVec3 cell in b.OccupiedRect())
-				{
-					if (mapComp.MapShipCells.ContainsKey(cell))
-						mapComp.MapShipCells.Remove(cell);
-				}
+				if (t is Building b && b.TryGetComp<CompShipCachePart>() != null)
+					GravshipDetach.DetachFromSos2(b);
 			}
 		}
 	}

--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -6130,6 +6130,20 @@ namespace SaveOurShip2
 		}
 	}
 
+	// SOS2 fuel-burning engines double as gravship thrusters that hold their own fuel: they carry a
+	// CompGravshipFacility with componentTypeDef Thruster + providesFuel. That covers the Thruster
+	// component and donates fuel (via their CompRefuelable), but does not register as a FuelStorage
+	// component. Drop the FuelStorage launch requirement when the gravship actually has fuel capacity.
+	[HarmonyPatch(typeof(Building_GravEngine), nameof(Building_GravEngine.MissingComponents), MethodType.Getter)]
+	public static class GravshipFuelStorageFromShipEngines
+	{
+		public static void Postfix(Building_GravEngine __instance, ref List<GravshipComponentTypeDef> __result)
+		{
+			if (__result.Count > 0 && __instance.MaxFuel > 0f && __result.Any(d => d.defName == "FuelStorage"))
+				__result = __result.Where(d => d.defName != "FuelStorage").ToList();
+		}
+	}
+
 	[HarmonyPatch(typeof(PlanetLayer), "ApproxDistanceInTiles", new Type[] { typeof(PlanetTile), typeof(PlanetTile) })]
 	public static class DistanceBetweendifferentLayersFix
 	{

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -98,6 +98,7 @@
   <ItemGroup>
     <Compile Include="AccuracyCalculator.cs" />
     <Compile Include="AISettings.cs" />
+    <Compile Include="CompShipEngineBreakdownable.cs" />
     <Compile Include="Alert\AlertDodgeChanceBase.cs" />
     <Compile Include="Alert\AlertDodgeChanceEnemy.cs" />
     <Compile Include="Alert\AlertDodgeChancePlayer.cs" />


### PR DESCRIPTION
SOS2 fueled engines can be used on gravship.

Added boundaries check to ensure they can't be both parts of SOS2 ship and gravship.

The way it is done is very simple - no actual intersection of mechanics, just a secondary set of comps, so should not cause any issues.