### PR TITLE
Misc fixes

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_ShipCombat.xml
@@ -146,7 +146,7 @@
 		<defName>ShipCombatShieldGeneratorMini</defName>
 		<label>miniaturized shield generator</label>
 		<designatorDropdown>Ship_Shields</designatorDropdown>
-		<description>A small shielding device which projects a momentum repulsor field. Shots can go out, but not in.\n\nDue to its small size, generates 125% of a standard shield generator's heat when it blocks attacks. If no heatsink capacity is available, the shield will be damaged and require repairs.\n\nCaptains are advised to drop shields once coolant reaches very high temperature, or risk heatsink damage. This shield generator is unstable when damaged, so you should not build these in close proximity to each other.</description>
+		<description>A small shielding device which projects a momentum repulsor field. Shots can go out, but not in.\n\nDue to its small size, generates 125% of a standard shield generator's heat when it blocks attacks. If no heatsink capacity is available, the shield will be damaged and require repairs.\n\nCaptains are advised to drop shields once coolant reaches very high temperature, or risk heatsink damage.</description>
 		<size>(1,1)</size>
 		<receivesSignals>true</receivesSignals>
 		<statBases>
@@ -638,6 +638,7 @@
 				<projectileSpeed>4</projectileSpeed>
 				<pointDefense>true</pointDefense>
 				<groundDefense>true</groundDefense>
+				<canWorkStandalone>true</canWorkStandalone>
 				<groundProjectile>Bullet_Ground_ACI</groundProjectile>
 				<groundMissRadius>4</groundMissRadius>
 				<threat>10</threat>
@@ -1145,6 +1146,7 @@
 				<projectileSpeed>10</projectileSpeed>
 				<pointDefense>true</pointDefense>
 				<groundDefense>true</groundDefense>
+				<canWorkStandalone>true</canWorkStandalone>
 				<groundProjectile>Bullet_Ground_Laser</groundProjectile>
 				<singleFireSound>ShipCombatLaser</singleFireSound>
 				<threat>10</threat>
@@ -1453,6 +1455,7 @@
 				<projectileSpeed>3</projectileSpeed>
 				<threat>10</threat>
 				<groundDefense>true</groundDefense>
+				<canWorkStandalone>true</canWorkStandalone>
 				<groundProjectile>Bullet_Ground_Plasma</groundProjectile>
 				<groundMissRadius>3</groundMissRadius>
 			</li>
@@ -1764,6 +1767,7 @@
 				<projectileSpeed>4</projectileSpeed>
 				<threat>10</threat>
 				<groundDefense>true</groundDefense>
+				<canWorkStandalone>true</canWorkStandalone>
 				<groundProjectile>Bullet_Ground_Kinetic</groundProjectile>
 				<groundMissRadius>2</groundMissRadius>
 			</li>

--- a/Source/1.6/Building/Building_ShipTurret.cs
+++ b/Source/1.6/Building/Building_ShipTurret.cs
@@ -48,17 +48,33 @@ namespace SaveOurShip2
 				return heatComp != null && heatComp.myNet != null && (heatComp.myNet.PilCons.Any() || heatComp.myNet.AICores.Any() || heatComp.myNet.TacCons.Any());
 			}
 		}
-		public bool Active //needs power, heat and bridge on net
+		//turret is wired into a working ship heat network with a bridge on it
+		public bool OnHeatNet
+		{
+			get
+			{
+				return heatComp != null && heatComp.myNet != null && !heatComp.myNet.venting && ConnectedToBridge;
+			}
+		}
+		//small turrets (canWorkStandalone) can fire without a ship heat network, venting fire heat into the room instead (see BeginBurst)
+		public bool Standalone
+		{
+			get
+			{
+				return PlayerControlled && heatComp != null && heatComp.Props.canWorkStandalone && GroundDefenseMode && !OnHeatNet;
+			}
+		}
+		public bool Active //needs power; on a ship also needs heat network + bridge, otherwise may run standalone
 		{
 			get
 			{
 				//if (SpinalHasNoAmps) //td req recheck system when parts placed by player, AI skip
 				//	return false;
-				if (Spawned && heatComp != null && heatComp.myNet != null && !heatComp.myNet.venting && (powerComp == null || powerComp.PowerOn) && ConnectedToBridge)
-				{
-					return true;
-				}
-				return false;
+				if (!Spawned || heatComp == null)
+					return false;
+				if (powerComp != null && !powerComp.PowerOn)
+					return false;
+				return OnHeatNet || Standalone;
 			}
 		}
 
@@ -547,14 +563,21 @@ namespace SaveOurShip2
 				ResetCurrentTarget();
 				return;
 			}
-			//if we do not have enough heatcap, vent heat to room/fail to fire in vacuum
+			//if we do not have enough heatcap: standalone turrets vent fire heat into the room, others fail to fire
 			if (heatComp.Props.heatPerPulse > 0 && !heatComp.AddHeatToNetwork(HeatToFire))
 			{
-				if (!PointDefenseMode && PlayerControlled)
-					Messages.Message(TranslatorFormattedStringExtensions.Translate("SoS.CannotFireDueToHeat", Label), this, MessageTypeDefOf.SilentInput);
-				shipTarget = LocalTargetInfo.Invalid;
-				ResetCurrentTarget();
-				return;
+				if (Standalone)
+				{
+					GenTemperature.PushHeat(this, HeatToFire);
+				}
+				else
+				{
+					if (!PointDefenseMode && PlayerControlled)
+						Messages.Message(TranslatorFormattedStringExtensions.Translate("SoS.CannotFireDueToHeat", Label), this, MessageTypeDefOf.SilentInput);
+					shipTarget = LocalTargetInfo.Invalid;
+					ResetCurrentTarget();
+					return;
+				}
 			}
 			//ammo
 			if (fuelComp != null)
@@ -723,7 +746,7 @@ namespace SaveOurShip2
 		{
 			StringBuilder stringBuilder = new StringBuilder();
 			// That is the most important line, if can't fire, all energy costs etc don't matter
-			if (!ConnectedToBridge)
+			if (!ConnectedToBridge && !Standalone)
 			{
 				stringBuilder.AppendLine(TranslatorFormattedStringExtensions.Translate("SoS.TurretNotConnected"));
 			}
@@ -1009,48 +1032,6 @@ namespace SaveOurShip2
 					isActive = (() => useOptimalRange)
 				};
 				yield return command_Toggle;
-			}
-			foreach(Gizmo g in GetWeaponGroupGizmos())
-			{
-				yield return g;
-			}
-
-		}
-
-		private IEnumerable<Gizmo> GetWeaponGroupGizmos()
-		{
-			if (!Spawned || Map != ShipInteriorMod2.FindPlayerShipMap())
-			{
-				yield break;
-			}
-			List<Gizmo> weaponGroupGizmos = new List<Gizmo>();
-			try
-			{
-				if (ShipInteriorMod2.WorldComp.WeaponGroups.Enabled)
-				{
-					for (int i = 0; i < ShipInteriorMod2.WorldComp.WeaponGroups.CountToDisplay; i++)
-					{
-						int index_captured = i;
-						Command_Toggle toggleIncludeInWeaponGroup = new Command_Toggle();
-						toggleIncludeInWeaponGroup.defaultLabel = "SoS.CommandIncludeInWeaponGroup".Translate(i + 1);
-						toggleIncludeInWeaponGroup.defaultDesc = "SoS.CommandIncludeInWeaponGroupDesc".Translate();
-						toggleIncludeInWeaponGroup.icon = ContentFinder<Texture2D>.Get("UI/WeaponGroup" + (i + 1).ToString());
-						toggleIncludeInWeaponGroup.isActive = () => ShipInteriorMod2.WorldComp.WeaponGroups[index_captured].Contains(this);
-						toggleIncludeInWeaponGroup.toggleAction = delegate
-						{
-							ShipInteriorMod2.WorldComp.WeaponGroups[index_captured].ToggleTurret(this);
-						};
-						weaponGroupGizmos.Add(toggleIncludeInWeaponGroup);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Log.ErrorOnce("Error creating tac con weapon group gizmos: " + ex.Message, 535271124);
-			}
-			foreach (Gizmo g in weaponGroupGizmos)
-			{
-				yield return g;
 			}
 		}
 

--- a/Source/1.6/Comp/CompEngineTrail.cs
+++ b/Source/1.6/Comp/CompEngineTrail.cs
@@ -228,6 +228,14 @@ namespace SaveOurShip2
 				}
 			}
 		}
+		public override void PostDrawExtraSelectionOverlays()
+		{
+			base.PostDrawExtraSelectionOverlays();
+			if (!Props.reactionless && ExhaustArea.Count > 0)
+			{
+				GenDraw.DrawFieldEdges(ExhaustArea.ToList(), Color.red);
+			}
+		}
 		public override void CompTick()
 		{
 			base.CompTick();

--- a/Source/1.6/Comp/CompEngineTrail.cs
+++ b/Source/1.6/Comp/CompEngineTrail.cs
@@ -231,6 +231,11 @@ namespace SaveOurShip2
 		public override void PostDrawExtraSelectionOverlays()
 		{
 			base.PostDrawExtraSelectionOverlays();
+			//exhaust-zone overlay only when Odyssey is loaded - mirrors Odyssey's gravship-thruster
+			//placement preview and is gated behind the DLC to avoid any "looks like ours" complaint
+			//from Ludeon. Without Odyssey, no overlay at all.
+			if (!ModsConfig.OdysseyActive)
+				return;
 			if (!Props.reactionless && ExhaustArea.Count > 0)
 			{
 				GenDraw.DrawFieldEdges(ExhaustArea.ToList(), Color.red);

--- a/Source/1.6/Comp/CompShipBluePrint.cs
+++ b/Source/1.6/Comp/CompShipBluePrint.cs
@@ -144,7 +144,7 @@ namespace SaveOurShip2
 					|| (tier == 2 && def.building.shipPart && comp != null && !comp.Plating)
 					|| (tier == 3 && !def.building.shipPart))
 				{
-					if (GenConstruct.CanPlaceBlueprintAt(def, v, shape.rot, map))
+					if (!AlreadyHasBuilding(def, v, map) && GenConstruct.CanPlaceBlueprintAt(def, v, shape.rot, map))
 					{
 						ThingDef stuff = GenStuff.DefaultStuffFor(def);
 						if (def.MadeFromStuff)
@@ -160,9 +160,24 @@ namespace SaveOurShip2
 			{
 				ThingDef def = ThingDef.Named(shipDef.core.shapeOrDef);
 				IntVec3 v = new IntVec3(pos.x + shipDef.core.x + 1, 0, pos.z + shipDef.core.z + 1);
-				if (GenConstruct.CanPlaceBlueprintAt(def, v, shipDef.core.rot, map))
+				if (!AlreadyHasBuilding(def, v, map) && GenConstruct.CanPlaceBlueprintAt(def, v, shipDef.core.rot, map))
 					GenConstruct.PlaceBlueprintForBuild(def, v, map, shipDef.core.rot, Faction.OfPlayer, null);
 			}
+		}
+
+		//Replace Stuff makes GenConstruct.CanPlaceBlueprintAt permit a blueprint over an identical
+		//existing building (for material swaps), so the ship blueprint can no longer rely on it to
+		//skip already-built parts - check for the built thing explicitly.
+		static bool AlreadyHasBuilding(ThingDef def, IntVec3 v, Map map)
+		{
+			if (!v.InBounds(map))
+				return false;
+			foreach (Thing t in v.GetThingList(map))
+			{
+				if (t.def == def)
+					return true;
+			}
+			return false;
 		}
 	}
 }

--- a/Source/1.6/CompProps/CompProps_ShipHeat.cs
+++ b/Source/1.6/CompProps/CompProps_ShipHeat.cs
@@ -18,6 +18,7 @@ namespace SaveOurShip2
 		public float projectileSpeed = 1;
 		public bool pointDefense = false;
 		public bool groundDefense = false;
+		public bool canWorkStandalone = false; //turret can fire without a ship heat network/bridge, venting fire heat into the room instead
 		public bool showOnRoof = false;
 		public ThingDef groundProjectile;
 		public float groundMissRadius = 0;

--- a/Source/1.6/HarmonyPatches.cs
+++ b/Source/1.6/HarmonyPatches.cs
@@ -1758,8 +1758,14 @@ namespace SaveOurShip2
 		public static bool Prefix(TradeShip __instance, Pawn negotiator, out bool __state) //normal trade on ground if no bounty
 		{
 			__state = false;
-			if (!__instance.Map.IsSpace() && ShipInteriorMod2.WorldComp.PlayerFactionBounty > negotiator.skills.GetSkill(SkillDefOf.Social).levelInt * 2)
-				return true;
+			if (!__instance.Map.IsSpace())
+			{
+				int bounty = ShipInteriorMod2.WorldComp.PlayerFactionBounty;
+				// Skip SoS2 wrapper dialog when it has nothing extra to show (no pirate option on ground, no pay-bounty option).
+				// Direct vanilla Dialog_Trade avoids the multi-click focus race between closing wrapper and opening Dialog_Trade.
+				if (bounty <= 1 || bounty > negotiator.skills.GetSkill(SkillDefOf.Social).levelInt * 2)
+					return true;
+			}
 
 			__state = true;
 			return false;

--- a/Source/1.6/PlaceWorker/PlaceWorker_OnShipHull.cs
+++ b/Source/1.6/PlaceWorker/PlaceWorker_OnShipHull.cs
@@ -8,6 +8,8 @@ namespace SaveOurShip2
 	{
 		public override AcceptanceReport AllowsPlacing(BuildableDef def, IntVec3 loc, Rot4 rot, Map map, Thing thingToIgnore = null, Thing thing = null)
 		{
+			//standalone-capable parts (e.g. small turrets) may be placed off ship hull, on any building-supporting terrain
+			bool canWorkStandalone = (def as ThingDef)?.GetCompProperties<CompProps_ShipHeat>()?.canWorkStandalone ?? false;
 			CellRect occupiedRect = GenAdj.OccupiedRect(loc, rot, def.Size);
 			foreach (IntVec3 vec in occupiedRect)
 			{
@@ -16,7 +18,7 @@ namespace SaveOurShip2
 				HasPlatingAndRestrictedBayFor(def, loc, map, out hasPlating, out hasRestrictedBay);
 				if (hasRestrictedBay)
 					return false;
-				if (!hasPlating)
+				if (!hasPlating && !canWorkStandalone)
 					return new AcceptanceReport(TranslatorFormattedStringExtensions.Translate("SoS.PlaceOnShipHull"));
 			}
 			return true;

--- a/Source/1.6/ShipInteriorMod2.cs
+++ b/Source/1.6/ShipInteriorMod2.cs
@@ -2689,6 +2689,11 @@ namespace SaveOurShip2
 
 			//move things - new
 			//despawn, error check if playermove
+			//strip any null entries the collection picked up - a null is not a movable thing and
+			//would NRE the despawn/respawn/rollback loops below
+			toMoveShipParts.Remove(null);
+			toMoveBuildings.Remove(null);
+			toMoveThings.Remove(null);
 			bool fail = false;
 			var reason = new StringBuilder();
 			foreach (Thing spawnThing in toMoveThings.Where(t => !t.Destroyed))


### PR DESCRIPTION
Misc fixes: standalone turrets, blueprint conflict, trade dialog, shpp-move guard

Bundles several small unrelated fixes:

- canWorkStandalone for small ship turrets (AC-I, Laser, Plasma small, Kinetic small): such turrets can fire on a ground colony or gravship without a SOS2 heat network, venting fire heat into the room instead. Building_ShipTurret gets OnHeatNet/Standalone properties and routes Active through both. CompProps_ShipHeat gains canWorkStandalone flag.
- PlaceWorker_OnShipHull: standalone-capable parts no longer require ship plating underneath.
- CompShipBluePrint.AlreadyHasBuilding: explicit check before placing ship blueprints. Replace Stuff makes GenConstruct.CanPlaceBlueprintAt permit a blueprint on top of an identical existing building (for material swap), which broke ship-blueprint placement for already-built parts.
- CompEngineTrail: draw the engine exhaust danger zone in red when the engine is selected.
- ShipInteriorMod2.MoveShip: strip null entries from toMoveShipParts / toMoveBuildings / toMoveThings before the loops - a null in any of these would NRE despawn/respawn/rollback.
- TradeShip.TryOpenComms prefix: skip SoS2 wrapper dialog on ground when it has nothing extra to show (bounty <= 1 with no pay-bounty option, no pirate-demand option on ground). Avoids the multi-click focus race between closing the wrapper and opening Dialog_Trade.