### PR TITLE
Added corner damage graphics processing: for empty/transparent parts of

### DIFF
--- a/Source/1.6/AssetPreprocessor.cs
+++ b/Source/1.6/AssetPreprocessor.cs
@@ -1,0 +1,112 @@
+using System.IO;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace SaveOurShip2
+{
+	[StaticConstructorOnStartup]
+	public static class AssetPreprocessor
+	{
+		static AssetPreprocessor()
+		{
+			ProcessCornerDefs();
+		}
+
+		private static void ProcessCornerDefs()
+		{
+			// Corner items have damage graphics set for all corners and sides. However, it's better to not have damage graphics in the empty part of the corner.
+			// Would be too tedious to do it in XML for 3 corners, x2 variants of flips x3 variants of style
+			ModContentPack content = LoadedModManager.GetMod<ShipInteriorMod2>().Content;
+			const float alphaThreshold = 0.1f;
+			const int delta = 4;
+			foreach (ThingDef corner in ResourceBank.CornerDefs)
+			{	
+				string texPath = corner.graphicData?.texPath;
+				if (texPath.NullOrEmpty() || corner.graphicData.damageData == null)
+				{
+					continue;
+				}
+				if (!TryLoadReadableTexture(content, texPath, out Texture2D tex))
+				{
+					Log.Error($"SoS 2: error when loading corner texture as readable: { corner.defName }");
+					continue;
+				}
+				int handledCornersCount = 0;
+				Color topLeft = tex.GetPixelsAroundAveraged(delta, tex.height - 1 - delta);
+				if (topLeft.a < alphaThreshold)
+				{
+					corner.graphicData.damageData.cornerTLMat = null;
+					// For the corner that has top left empty and sharp ends at top right and bottom left,
+					// remove damage graphics from those 2 sharp corners too as corner damage graphics have 
+					// quite long sides and will be drawn over empty/transparent part of the texture.
+					corner.graphicData.damageData.cornerTRMat = null;
+					corner.graphicData.damageData.cornerBLMat = null;
+					corner.graphicData.damageData.edgeTopMat = null;
+					corner.graphicData.damageData.edgeLeftMat = null;
+					handledCornersCount++;
+				}
+				// Handle other corners similar to top left
+				Color bottomLeft = tex.GetPixelsAroundAveraged(delta, delta);
+				if (bottomLeft.a < alphaThreshold)
+				{
+					corner.graphicData.damageData.cornerBLMat = null;
+					corner.graphicData.damageData.cornerTLMat = null;
+					corner.graphicData.damageData.cornerBRMat = null;
+					corner.graphicData.damageData.edgeBotMat = null;
+					corner.graphicData.damageData.edgeLeftMat = null;
+					handledCornersCount++;
+				}
+				Color topRight = tex.GetPixelsAroundAveraged(tex.width - 1 - delta, tex.height - 1 - delta);
+				if (topRight.a < alphaThreshold)
+				{
+					corner.graphicData.damageData.cornerTRMat = null;
+					corner.graphicData.damageData.cornerBRMat = null;
+					corner.graphicData.damageData.cornerTLMat = null;
+					corner.graphicData.damageData.edgeTopMat = null;
+					corner.graphicData.damageData.edgeRightMat = null;
+					handledCornersCount++;
+				}
+				Color bottomRight = tex.GetPixelsAroundAveraged(tex.width - 1 - delta, delta);
+				if (bottomRight.a < alphaThreshold)
+				{
+					corner.graphicData.damageData.cornerBRMat = null;
+					corner.graphicData.damageData.cornerTRMat = null;
+					corner.graphicData.damageData.cornerBLMat = null;
+					corner.graphicData.damageData.edgeBotMat = null;
+					corner.graphicData.damageData.edgeRightMat = null;
+					handledCornersCount++;
+				}
+				if(handledCornersCount != 1)
+				{
+					Log.Error($"SoS 2: Error preprocessing corner damage graphics for: {corner.defName} { handledCornersCount }");
+				}
+				Object.Destroy(tex);
+			}
+		}
+		static bool TryLoadReadableTexture(ModContentPack content, string texPath, out Texture2D tex)
+		{
+			tex = null;
+			string file = Path.Combine(content.RootDir, "Textures", texPath + ".png");
+			if (!File.Exists(file))
+				return false;
+			tex = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+			return tex.LoadImage(File.ReadAllBytes(file));
+		}
+
+		static Color GetPixelsAroundAveraged(this Texture2D tex, int x, int y)
+		{
+			Color result = Color.clear;
+			int delta = 1;
+			for (int dx = -delta; dx <= delta; dx++)
+			{
+				for(int dy  = -delta; dy <= delta; dy++)
+				{
+					result += tex.GetPixel(x + dx, y + dy);
+				}
+			}
+			float sampleSize = (float)(delta * 2 + 1);
+			return result / sampleSize / sampleSize;
+		}
+	}
+}

--- a/Source/1.6/ResourceBank.cs
+++ b/Source/1.6/ResourceBank.cs
@@ -153,6 +153,27 @@ namespace SaveOurShip2
 			public static ThingDef JTDriveSalvage;
 			public static ThingDef ShipCombatShieldGeneratorMini;
 			public static ThingDef ShipHardpointSmall;
+
+			//Corners
+			public static ThingDef Ship_Corner_OneOne;
+			public static ThingDef Ship_Corner_OneOneFlip;
+			public static ThingDef Ship_Corner_OneTwo;
+			public static ThingDef Ship_Corner_OneTwoFlip;
+			public static ThingDef Ship_Corner_OneThree;
+			public static ThingDef Ship_Corner_OneThreeFlip;
+			public static ThingDef Ship_Corner_OneOne_Mech;
+			public static ThingDef Ship_Corner_OneOne_MechFlip;
+			public static ThingDef Ship_Corner_OneTwo_Mech;
+			public static ThingDef Ship_Corner_OneTwoFlip_Mech;
+			public static ThingDef Ship_Corner_OneThree_Mech;
+			public static ThingDef Ship_Corner_OneThreeFlip_Mech;
+			public static ThingDef Ship_Corner_Archo_OneOne;
+			public static ThingDef Ship_Corner_Archo_OneOneFlip;
+			public static ThingDef Ship_Corner_Archo_OneTwo;
+			public static ThingDef Ship_Corner_Archo_OneTwoFlip;
+			public static ThingDef Ship_Corner_Archo_OneThree;
+			public static ThingDef Ship_Corner_Archo_OneThreeFlip;
+
 			//vanilla defs
 			public static ThingDef Turret_Autocannon;
 			public static ThingDef Turret_Sniper;
@@ -446,5 +467,28 @@ namespace SaveOurShip2
 				ThingDefOf.Ship_BeamArchotech_Unpowered,
 				ThingDefOf.Ship_Beam_Wrecked
 		};
+
+		public static readonly List<ThingDef> CornerDefs = new List<ThingDef>()
+		{
+			ThingDefOf.Ship_Corner_OneOne,
+			ThingDefOf.Ship_Corner_OneOneFlip,
+			ThingDefOf.Ship_Corner_OneTwo,
+			ThingDefOf.Ship_Corner_OneTwoFlip,
+			ThingDefOf.Ship_Corner_OneThree,
+			ThingDefOf.Ship_Corner_OneThreeFlip,
+			ThingDefOf.Ship_Corner_OneOne_Mech,
+			ThingDefOf.Ship_Corner_OneOne_MechFlip,
+			ThingDefOf.Ship_Corner_OneTwo_Mech,
+			ThingDefOf.Ship_Corner_OneTwoFlip_Mech,
+			ThingDefOf.Ship_Corner_OneThree_Mech,
+			ThingDefOf.Ship_Corner_OneThreeFlip_Mech,
+			ThingDefOf.Ship_Corner_Archo_OneOne,
+			ThingDefOf.Ship_Corner_Archo_OneOneFlip,
+			ThingDefOf.Ship_Corner_Archo_OneTwo,
+			ThingDefOf.Ship_Corner_Archo_OneTwoFlip,
+			ThingDefOf.Ship_Corner_Archo_OneThree,
+			ThingDefOf.Ship_Corner_Archo_OneThreeFlip,
+		};
+
 	}
 }

--- a/Source/1.6/RimworldMod.csproj
+++ b/Source/1.6/RimworldMod.csproj
@@ -99,6 +99,7 @@
     <Compile Include="AccuracyCalculator.cs" />
     <Compile Include="AISettings.cs" />
     <Compile Include="Alert\AlertTWR.cs" />
+    <Compile Include="AssetPreprocessor.cs" />
     <Compile Include="CompShipEngineBreakdownable.cs" />
     <Compile Include="Alert\AlertDodgeChanceBase.cs" />
     <Compile Include="Alert\AlertDodgeChanceEnemy.cs" />


### PR DESCRIPTION
corners, damage graphics are set to null in C# to minimize showing damage graphics over empty space, which looks unnatural.