### PR TITLE
Fixed random plants spawn

### DIFF
--- a/Source/1.6/ModIntegration.cs
+++ b/Source/1.6/ModIntegration.cs
@@ -6,6 +6,8 @@ namespace SaveOurShip2
 {
 	public class ModIntegration
 	{
+		// This just properly checks for single active mod. Which includes both unchanged mod name
+		// and name with steam suffix.
 		public static bool HasActiveModWithIdentifierAndOptionalSuffix(string modID)
 		{
 			string suffixedModID = modID + "_steam";
@@ -33,6 +35,12 @@ namespace SaveOurShip2
 		// Because of Odyssey changes, need to place world objects further from each other,
 		// as zoomin in in orbit normally results in hiding orbit, switching to syrface layer.
 		public const float NewOdyOffsetScale = 2.5f;
+
+		public static bool IsSOS2ContentPack(ModContentPack pack)
+		{
+			ModContentPack sos2ContentPack = LoadedModManager.GetMod<ShipInteriorMod2>().Content;
+			return sos2ContentPack == pack;
+		}
 	}
 }
 

--- a/Source/1.6/ShipInteriorMod2.cs
+++ b/Source/1.6/ShipInteriorMod2.cs
@@ -325,16 +325,13 @@ namespace SaveOurShip2
 		{
 			Log.Message("SOS2 " + SOS2version + " active");
 
-			string[] disallowedPlants = new string[]{
-				// Elder ocular tree from Vanilla Psycasts Expanded
-				"AA_ElderAlienTree",
-				// RA_MetalBean is from Ratkin Anomaly+, causes real bad effects and was requested to not spawn randomly.
-				"RA_MetalBean",
-				// Archean tree converts soil, so not suitable for placing on ship.
-				"Plant_TreeArchean"
-			};
-
-			randomPlants = DefDatabase<ThingDef>.AllDefs.Where(t => t.plant != null && !t.defName.Contains("Anima") && !disallowedPlants.Contains(t.defName)).ToList();
+			// Only allow vanilla and SOS 2 plants, as they are enough to make ship grdens look wild.
+			// Plants fom mods caused errors.
+			
+			randomPlants = DefDatabase<ThingDef>.AllDefs.Where(t => t.plant != null &&
+				(ModIntegration.IsSOS2ContentPack(t.modContentPack) || t.modContentPack.IsOfficialMod) &&
+				!t.defName.Contains("Anima") && // Anima tree is disallowed
+				!t.plant.diesToLight).ToList(); // Darkness plants like cave mushrooms aren't supposed to grow in lit ship gardens
 
 			foreach (ShipDef ship in DefDatabase<ShipDef>.AllDefs.Where(d => d.saveSysVer < 2 && !d.neverRandom).ToList())
 			{


### PR DESCRIPTION
Only SOS 2 plants and Vanilla plants are allowed on ship gardens, almost all of them, with a few exceptions.