### PR TITLE
Fixed stashed ship site part selection weight, set to 0, so it shouldn't

### DIFF
--- a/1.6/Defs/Sites/Cores/Space.xml
+++ b/1.6/Defs/Sites/Cores/Space.xml
@@ -144,6 +144,7 @@
     <expandingIconTexture>World/WorldObjects/Expanding/Sites/ItemStash</expandingIconTexture>
     <handlesWorldObjectTimeoutInspectString>true</handlesWorldObjectTimeoutInspectString>
 	<minMapSize>(250, 0, 250)</minMapSize>
+	<selectionWeight>0</selectionWeight>
     <tags>
       <li>SoSStashedShip</li>
       <li>QuestActiveThreat</li>


### PR DESCRIPTION
be randomly selected and added to various generated quests, only forced in it's own hardcoded quest generated on comms console request.